### PR TITLE
Updates the db migration symlinks

### DIFF
--- a/db/migrations/20170405113830_create-accounts-table.js
+++ b/db/migrations/20170405113830_create-accounts-table.js
@@ -1,1 +1,1 @@
-../../../dogstack-agents/db/migrations/20170405113830_create-accounts-table.js
+../../node_modules/dogstack-agents/db/migrations/20170405113830_create-accounts-table.js

--- a/db/migrations/20170406133405_create-agent-table.js
+++ b/db/migrations/20170406133405_create-agent-table.js
@@ -1,1 +1,1 @@
-../../../dogstack-agents/db/migrations/20170406133405_create-agent-table.js
+../../node_modules/dogstack-agents/db/migrations/20170406133405_create-agent-table.js


### PR DESCRIPTION
previously this pointed to dogstack-agents as a seperate repo, this points it to node-modules/dogstack-agents an npm dependancy.