### PR TITLE
add implicit child plans to getTaskPlans

### DIFF
--- a/tasks/getters/getTaskPlans.js
+++ b/tasks/getters/getTaskPlans.js
@@ -50,6 +50,28 @@ const getTaskPlanTree = createSelector(
         .filter(complement(isNil))
     }
 
+    // default any missing child plans where child recipes exist
+    Object.keys(taskPlansById).forEach(taskPlanId => {
+      var taskPlan = taskPlanTree[taskPlanId]
+      const { assignee, taskRecipe, childTaskPlans } = taskPlan
+      const childPlanRecipeIds = childTaskPlans
+        .map(({ taskRecipe: { id } }) => id)
+      const { childTaskRecipes = [] } = taskRecipe
+      const missingRecipes = childTaskRecipes
+        .filter(taskRecipe => {
+          return !childTaskPlans.find(taskPlan => {
+            return taskPlan.taskRecipe.id === taskRecipe.id
+          })
+        })
+      missingRecipes.forEach(taskRecipe => {
+        taskPlan.childTaskPlans.push({
+          taskRecipeId: taskRecipe.id,
+          taskRecipe,
+          assignee
+        })
+      })
+    })
+
     // resolve parents as well
     Object.keys(taskPlansById).forEach(taskPlanId => {
       var taskPlan = taskPlanTree[taskPlanId]


### PR DESCRIPTION
an "implicit child plan" is where the parent task has a child recipe but no corresponding child plan.

---

@gregorykan: i think we need to re-visit task getters in general. when i wrote the TaskWorker component, i made a first pass at the data structure returned: https://github.com/root-systems/cobuy/blob/c44d2726ec559fa5eb7c8bbcfbee6b21737b2c71/tasks/stories/TaskWorker.js#L17-L37, but now since TaskWorks no longer need a corresponding TaskPlan, i think we need to re-think this.

then there's this case, where i took the "implicit child plan" approach, so we can create a single parent plan to count for all the child plans, but i'm not sure this is the best approach.

also i wonder if the role of the getter is to turn all these separate Recipe, Plan, and Work objects into a single conceptual "Task".
 
hmm.