### PR TITLE
add type json-schemas for all data models

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ cp cobuy-config/*.js cobuy/config
 heroku run npm run db migrate:latest --app=cobuy
 ```
 
+### JSON schema
+
+All models must have an assoicated JSON schema. See [#118](https://github.com/root-systems/cobuy/issues/118) for more info.
+
 ### How to [storybook](https://storybook.js.org)
 
 So you want to tell a story about dumb React components, ey?

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ heroku run npm run db migrate:latest --app=cobuy
 
 All models must have an assoicated JSON schema. See [#118](https://github.com/root-systems/cobuy/issues/118) for more info.
 
+We're using [json-schema-faker](https://github.com/json-schema-faker/json-schema-faker/#faking-values) to fake data for tests and storybook.
+
 ### How to [storybook](https://storybook.js.org)
 
 So you want to tell a story about dumb React components, ey?

--- a/agents/schemas/profile.json
+++ b/agents/schemas/profile.json
@@ -30,7 +30,6 @@
   },
   "required": [
     "id",
-    "agentId",
-    "name"
+    "agentId"
   ]
 }

--- a/agents/schemas/profile.json
+++ b/agents/schemas/profile.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "agents/Profile",
+  "title": "Profile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Id referencing profile"
+    },
+    "agentId": {
+      "type": "integer",
+      "description": "Id referencing agent"
+    },
+    "name": {
+      "type": "string",
+      "description": "An agent name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Agent biography"
+    },
+    "avatar" : {
+      "type": "string",
+      "format": "uri",
+      "description": "Agent avatar image link"
+    }
+  },
+  "required": [
+    "id",
+    "agentId",
+    "name"
+  ]
+}

--- a/agents/schemas/profile.json
+++ b/agents/schemas/profile.json
@@ -14,6 +14,7 @@
     },
     "name": {
       "type": "string",
+      "faker": "name.findName",
       "description": "An agent name"
     },
     "description": {
@@ -22,6 +23,7 @@
     },
     "avatar" : {
       "type": "string",
+      "faker": "internet.avatar",
       "format": "uri",
       "description": "Agent avatar image link"
     }

--- a/agents/stories/Profile.js
+++ b/agents/stories/Profile.js
@@ -2,16 +2,17 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { reduxForm, Field } from 'redux-form'
+import h from 'react-hyperscript'
 import jsf from 'json-schema-faker'
 
 import schema from '../schemas/profile'
 import Profile from '../components/Profile'
 
-const fakeAgent = {
-  profile: jsf(schema)
-}
+const profile = jsf(schema)
 
 storiesOf('agents.Profile', module)
   .add('basic', () => (
-      <Profile agent={fakeAgent} />
+      h(Profile, {
+        initialValues: profile
+      })
   ))

--- a/agents/stories/Profile.js
+++ b/agents/stories/Profile.js
@@ -2,17 +2,16 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import { reduxForm, Field } from 'redux-form'
+import jsf from 'json-schema-faker'
 
+import schema from '../schemas/profile'
 import Profile from '../components/Profile'
 
-const alice = {
-  profile: {
-    name: 'Alice',
-    description: 'a cool cat',
-    avatar: 'http://dinosaur.is/images/mikey-small.jpg'
-  }
+const fakeAgent = {
+  profile: jsf(schema)
 }
+
 storiesOf('agents.Profile', module)
   .add('basic', () => (
-    <Profile agent={alice} />
+      <Profile agent={fakeAgent} />
   ))

--- a/app/schemas.js
+++ b/app/schemas.js
@@ -1,0 +1,11 @@
+const Ajv = require('ajv')
+const ajv = new Ajv()
+
+const taskPlanSchema = require('../tasks/schemas/taskPlan')
+const taskRecipeSchema = require('../tasks/schemas/taskRecipe')
+ajv.addSchema([
+  taskRecipeSchema,
+  taskPlanSchema
+])
+
+export default ajv

--- a/ordering/services/orders.js
+++ b/ordering/services/orders.js
@@ -58,9 +58,9 @@ function createPrereqTaskPlan (hook) {
   // const assigneeId = hook.params.agent.id
 
   const assigneeId = hook.params.credential.agentId
-  const params = JSON.stringify({
+  const params = {
     contextAgentId: hook.data.agentId
-  })
+  }
   return taskPlans.create({ taskRecipeId, params, assigneeId })
   .then(() => {
     return hook

--- a/package-lock.json
+++ b/package-lock.json
@@ -418,11 +418,13 @@
       }
     },
     "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.2.tgz",
+      "integrity": "sha1-R8aNaehvXZUxA7AHSpQw3GPaXjk=",
       "requires": {
         "co": "4.6.0",
+        "fast-deep-equal": "1.0.0",
+        "json-schema-traverse": "0.3.1",
         "json-stable-stringify": "1.0.1"
       }
     },
@@ -6835,6 +6837,18 @@
       "requires": {
         "ajv": "4.11.8",
         "har-schema": "1.0.5"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        }
       }
     },
     "has": {
@@ -15040,6 +15054,15 @@
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
           "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "dependency-check": "^2.8.0",
     "maildev": "^1.0.0-rc3",
     "npm-run-all": "^4.0.2",
+    "json-schema-faker": "^0.4.3",
     "precinct": "^3.6.0",
     "sqlite3": "3.1.8"
   }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@ahdinosaur/react-fela": "^4.3.5",
     "@f/create-action": "^1.1.1",
     "@root-systems/redux-form-validators": "^1.1.0",
+    "ajv": "^5.2.2",
     "babel-plugin-ramda": "^1.2.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",

--- a/tasks/data/mock.js
+++ b/tasks/data/mock.js
@@ -90,7 +90,7 @@ export const mockEnhancedTaskPlans = {
     taskRecipeId: 'finishPrereqs',
     taskRecipe: finishPrereqs,
     params: {
-      contextAgent: group
+      contextAgentId: group.id
     }
   },
   2: {
@@ -100,7 +100,7 @@ export const mockEnhancedTaskPlans = {
     taskRecipeId: 'setupGroup',
     taskRecipe: setupGroup,
     params: {
-      contextAgent: group
+      contextAgentId: group.id
     }
   },
   3: {
@@ -110,7 +110,7 @@ export const mockEnhancedTaskPlans = {
     taskRecipeId: 'setupSupplier',
     taskRecipe: setupSupplier,
     params: {
-      contextAgent: group
+      contextAgentId: group.id
     }
   }
 }

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://localhost:3000/tasks/schemas/taskPlan.json",
+  "id": "/tasks/taskPlan",
   "title": "Task Plan",
   "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
   "type": "object",
@@ -17,7 +17,7 @@
       "description": "Person or group or related agents (e.g. admins) being assigned"
     },
     "taskRecipeId": {
-        "$ref": "http://localhost:3000/tasks/schemas/taskRecipe.json#/definitions/id",
+        "$ref": "/tasks/taskRecipe#/definitions/id",
         "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED"
     },
       "params": {

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -17,7 +17,7 @@
       "description": "Person or group or related agents (e.g. admins) being assigned"
     },
     "taskRecipeId": {
-        "$ref": "http://localhost:3000/tasks/schemas/taskRecipe.json#/id",
+        "$ref": "http://localhost:3000/tasks/schemas/taskRecipe.json#/definitions/id",
         "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED"
     },
       "params": {

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -5,12 +5,10 @@
   "type": "object",
   "properties": {
     "id": {
-      "type": "integer",
-      "description": "Id referencing task plan"
+      "$ref": "#/definitions/id"
     },
     "parentTaskPlanID": {
-      "type": "integer",
-      "description": "Id referencing the associated task plan"
+      "$ref": "#/definitions/id"
     },
     "assigneeId": {
       "type": "integer",
@@ -28,5 +26,11 @@
   "required": [
     "assigneeId",
     "taskRecipeId"
-  ]
+  ],
+  "definitions": {
+    "id": {
+      "type": "integer",
+      "description": "Id referencing task plan"
+    }
+  }
 }

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "tasks/taskPlan",
+  "title": "Task Plan",
+  "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Id referencing task plan"
+    },
+    "parentTaskPlanID": {
+      "type": "integer",
+      "description": "Id referencing the associated task plan"
+    },
+    "assignee": {
+      "type": "integer",
+      "description": "Person or group or related agents (e.g. admins) being assigned"
+    },
+    "taskRecipeId": {
+        "$ref": "taskRecipe.json#/id",
+        "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED"
+    }
+  },
+  "required": [
+    "id",
+    "assignee",
+    "taskRecipeId"
+  ]
+}

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "id": "tasks/taskPlan",
+  "id": "http://localhost:3000/tasks/schemas/taskPlan.json",
   "title": "Task Plan",
   "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
   "type": "object",
@@ -13,18 +12,21 @@
       "type": "integer",
       "description": "Id referencing the associated task plan"
     },
-    "assignee": {
+    "assigneeId": {
       "type": "integer",
       "description": "Person or group or related agents (e.g. admins) being assigned"
     },
     "taskRecipeId": {
-        "$ref": "taskRecipe.json#/id",
+        "$ref": "http://localhost:3000/tasks/schemas/taskRecipe.json#/id",
         "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED"
-    }
+    },
+      "params": {
+        "type": "object",
+        "description": ""
+      }
   },
   "required": [
-    "id",
-    "assignee",
+    "assigneeId",
     "taskRecipeId"
   ]
 }

--- a/tasks/schemas/taskPlan.json
+++ b/tasks/schemas/taskPlan.json
@@ -1,7 +1,7 @@
 {
   "id": "/tasks/taskPlan",
   "title": "Task Plan",
-  "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
+  "description": "An assignment of the task to an agent",
   "type": "object",
   "properties": {
     "id": {
@@ -17,13 +17,13 @@
       "description": "Person or group or related agents (e.g. admins) being assigned"
     },
     "taskRecipeId": {
-        "$ref": "/tasks/taskRecipe#/definitions/id",
-        "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED"
+      "$ref": "/tasks/taskRecipe#/definitions/id",
+      "description": "Task recipe that this taask plan is related to"
     },
-      "params": {
-        "type": "object",
-        "description": ""
-      }
+    "params": {
+      "type": "object",
+      "description": "Util paramaters"
+    }
   },
   "required": [
     "assigneeId",

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -15,15 +15,20 @@
     "taskRecipe": {
       "type": "object",
       "properties": {
-        "taskRecipeId": {
+        "id": {
           "$ref": "#/definitions/id"
         },
         "childTaskRecipes": {
-          "$ref": "#/definitions/taskRecipe"
+          "type": "array",
+          "items": [
+            {
+              "$ref": "#/definitions/taskRecipe"
+            }
+          ]
         }
       },
       "required": [
-        "taskRecipeId"
+        "id"
       ]
     }
   }

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -1,9 +1,26 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "id": "tasks/taskRecipe",
+  "id": "http://localhost:3000/tasks/schemas/taskRecipe.json",
   "title": "Task Recipe",
-  "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
-  "$ref": "#/definitions/taskRecipe",
+  "description": "An abstract description of the task",
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "#/id"
+    },
+    "ownerAgentId": {
+      "type": "integer",
+      "description": "Id of the agent that owns the recipe"
+    },
+    "childTaskRecipes": {
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#"
+        }
+      ],
+      "description": "Task recipes that make up this task recipe..."
+    }
+  },
   "definitions": {
     "id": {
       "enum": [
@@ -11,25 +28,9 @@
         "setupSupplier",
         "finishPrereqs"
       ]
-    },
-    "taskRecipe": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "$ref": "#/definitions/id"
-        },
-        "childTaskRecipes": {
-          "type": "array",
-          "items": [
-            {
-              "$ref": "#/definitions/taskRecipe"
-            }
-          ]
-        }
-      },
-      "required": [
-        "id"
-      ]
     }
-  }
+  },
+  "required": [
+    "id"
+  ]
 }

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "id": {
-      "$ref": "#/id"
+      "$ref": "#/definitions/id"
     },
     "ownerAgentId": {
       "type": "integer",

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "id": "tasks/taskRecipe",
+  "title": "Task Recipe",
+  "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
+  "type": "object",
+  "properties": {
+    "id": {
+      "$ref": "#/definitions/id"
+    }
+  },
+  "required": [
+    "id"
+  ],
+  "definitions": {
+    "id": { "enum": [ "setupGroup", "setupSupplier", "finishPrereqs"] }
+  }
+}

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -3,16 +3,28 @@
   "id": "tasks/taskRecipe",
   "title": "Task Recipe",
   "description": "WILL NEED TO FILL IN ONCE #125 HAS BEEN ANSWERED",
-  "type": "object",
-  "properties": {
-    "id": {
-      "$ref": "#/definitions/id"
-    }
-  },
-  "required": [
-    "id"
-  ],
+  "$ref": "#/definitions/taskRecipe",
   "definitions": {
-    "id": { "enum": [ "setupGroup", "setupSupplier", "finishPrereqs"] }
+    "id": {
+      "enum": [
+        "setupGroup",
+        "setupSupplier",
+        "finishPrereqs"
+      ]
+    },
+    "taskRecipe": {
+      "type": "object",
+      "properties": {
+        "taskRecipeId": {
+          "$ref": "#/definitions/id"
+        },
+        "childTaskRecipes": {
+          "$ref": "#/definitions/taskRecipe"
+        }
+      },
+      "required": [
+        "taskRecipeId"
+      ]
+    }
   }
 }

--- a/tasks/schemas/taskRecipe.json
+++ b/tasks/schemas/taskRecipe.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://localhost:3000/tasks/schemas/taskRecipe.json",
+  "id": "/tasks/taskRecipe",
   "title": "Task Recipe",
   "description": "An abstract description of the task",
   "type": "object",

--- a/tasks/services/plans.js
+++ b/tasks/services/plans.js
@@ -21,9 +21,18 @@ module.exports = function () {
 
 const hooks = {
   before: {
-    create: [validateSchema(taskPlanSchema, ajv), encodeParams],
-    update: [validateSchema(taskPlanSchema, ajv), encodeParams],
-    patch: [validateSchema(taskPlanSchema, ajv), encodeParams]
+    create: [
+      validateSchema(taskPlanSchema, ajv),
+      encodeParams
+    ],
+    update: [
+      validateSchema(taskPlanSchema, ajv),
+      encodeParams
+    ],
+    patch: [
+      validateSchema(taskPlanSchema, ajv),
+      encodeParams
+    ]
   },
   after: {
     all: [

--- a/tasks/services/plans.js
+++ b/tasks/services/plans.js
@@ -6,7 +6,6 @@ const taskPlanSchema = require('../schemas/taskPlan')
 const taskRecipeSchema = require('../schemas/taskRecipe')
 const ajv = new Ajv({$data: true})
 ajv.addSchema([taskRecipeSchema, taskPlanSchema])
-import { isEmpty } from 'ramda'
 import * as taskRecipes from '../../tasks/data/recipes'
 
 module.exports = function () {
@@ -22,13 +21,9 @@ module.exports = function () {
 
 const hooks = {
   before: {
-    all: [
-      // encodeParams
-    ],
-    create: [
-      logEvent,
-      validateSchema(taskPlanSchema, ajv)
-    ]
+    create: [validateSchema(taskPlanSchema, ajv), encodeParams],
+    update: [validateSchema(taskPlanSchema, ajv), encodeParams],
+    patch: [validateSchema(taskPlanSchema, ajv), encodeParams]
   },
   after: {
     all: [
@@ -56,11 +51,11 @@ function createChildTaskPlans (hook) {
         parentTaskPlanId: hook.result.id,
         assigneeId: hook.data.assigneeId,
         taskRecipeId: childTaskRecipe.id,
-        params: hook.data.params
+        params: hook.result.params
       })
     })
   )
-  .then(() => hook)
+    .then(() => hook)
 }
 
 const transformProp = transformer => propName => object => pipe(
@@ -87,8 +82,4 @@ function decodeParams (hook) {
   if (hook.result) {
     hook.result = transformPropMaybeArray(JSON.parse)('params')(hook.result)
   }
-}
-function logEvent (hook) {
-  console.log(hook.data)
-  return hook
 }

--- a/tasks/services/plans.js
+++ b/tasks/services/plans.js
@@ -1,8 +1,11 @@
 const feathersKnex = require('feathers-knex')
 import { isEmpty, ifElse, is, assoc, prop, map, pipe, __ } from 'ramda'
 const { iff, validateSchema } = require('feathers-hooks-common')
-const ajv = require('ajv')
+const Ajv = require('ajv')
+const taskPlanSchema = require('../schemas/taskPlan')
 const taskRecipeSchema = require('../schemas/taskRecipe')
+const ajv = new Ajv({$data: true})
+ajv.addSchema([taskRecipeSchema, taskPlanSchema])
 import { isEmpty } from 'ramda'
 import * as taskRecipes from '../../tasks/data/recipes'
 
@@ -23,7 +26,8 @@ const hooks = {
       // encodeParams
     ],
     create: [
-      validateSchema(taskRecipeSchema, ajv)
+      logEvent,
+      validateSchema(taskPlanSchema, ajv)
     ]
   },
   after: {
@@ -83,5 +87,8 @@ function decodeParams (hook) {
   if (hook.result) {
     hook.result = transformPropMaybeArray(JSON.parse)('params')(hook.result)
   }
+}
+function logEvent (hook) {
+  console.log(hook.data)
   return hook
 }

--- a/tasks/services/plans.js
+++ b/tasks/services/plans.js
@@ -1,11 +1,8 @@
 const feathersKnex = require('feathers-knex')
 import { isEmpty, ifElse, is, assoc, prop, map, pipe, __ } from 'ramda'
 const { iff, validateSchema } = require('feathers-hooks-common')
-const Ajv = require('ajv')
 const taskPlanSchema = require('../schemas/taskPlan')
-const taskRecipeSchema = require('../schemas/taskRecipe')
-const ajv = new Ajv({$data: true})
-ajv.addSchema([taskRecipeSchema, taskPlanSchema])
+import ajv from '../../app/schemas'
 import * as taskRecipes from '../../tasks/data/recipes'
 
 module.exports = function () {

--- a/tasks/services/plans.js
+++ b/tasks/services/plans.js
@@ -1,6 +1,9 @@
 const feathersKnex = require('feathers-knex')
-const { iff } = require('feathers-hooks-common')
 import { isEmpty, ifElse, is, assoc, prop, map, pipe, __ } from 'ramda'
+const { iff, validateSchema } = require('feathers-hooks-common')
+const ajv = require('ajv')
+const taskRecipeSchema = require('../schemas/taskRecipe')
+import { isEmpty } from 'ramda'
 import * as taskRecipes from '../../tasks/data/recipes'
 
 module.exports = function () {
@@ -18,6 +21,9 @@ const hooks = {
   before: {
     all: [
       // encodeParams
+    ],
+    create: [
+      validateSchema(taskRecipeSchema, ajv)
     ]
   },
   after: {

--- a/tasks/util/createTaskRecipe.test.js
+++ b/tasks/util/createTaskRecipe.test.js
@@ -1,0 +1,25 @@
+import test from 'ava'
+
+import * as taskRecipes from '../data/recipes'
+
+const ajv = require('ajv')
+const { validateSchema } = require('feathers-hooks-common')
+const schema = require('../schemas/taskRecipe')
+
+test('create simple recipe', (t) => {
+  const hookBefore = {
+    type: 'before',
+    method: 'create',
+    params: { provider: 'rest' },
+    data: taskRecipes.setupSupplier
+  }
+  try {
+    validateSchema(schema, ajv)(hookBefore)
+  } catch (err) {
+    if (err.errors) {
+      console.log('validation errors: ', err.errors)
+    }
+    t.fail('creation failed unexpectedly')
+  }
+  t.pass('recipe was created')
+})

--- a/tasks/util/validateTaskPlan.test.js
+++ b/tasks/util/validateTaskPlan.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import jsf from 'json-schema-faker'
+import * as mock from '../data/mock'
 
 const Ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
@@ -12,15 +12,13 @@ ajv.addSchema([taskRecipeSchema, schema])
 let hookBefore
 
 test.beforeEach(t => {
-  return jsf.resolve(schema).then((result) => {
-    hookBefore = {
-      type: 'before',
-      method: 'create',
-      params: { provider: 'rest' },
-      data: result
-    }
-    console.log(hookBefore.data)
-  })
+  hookBefore = {
+    type: 'before',
+    method: 'create',
+    params: { provider: 'rest' },
+    data: mock.mockTaskPlans[1]
+  }
+  console.log(hookBefore.data)
 })
 
 test('works with simple plan', (t) => {

--- a/tasks/util/validateTaskPlan.test.js
+++ b/tasks/util/validateTaskPlan.test.js
@@ -1,0 +1,36 @@
+import test from 'ava'
+import jsf from 'json-schema-faker'
+
+const Ajv = require('ajv')
+const { validateSchema } = require('feathers-hooks-common')
+const schema = require('../schemas/taskPlan')
+const taskRecipeSchema = require('../schemas/taskRecipe')
+
+let ajv = new Ajv({ $data: true })
+ajv.addSchema([taskRecipeSchema, schema])
+
+let hookBefore
+
+test.beforeEach(t => {
+  return jsf.resolve(schema).then((result) => {
+    hookBefore = {
+      type: 'before',
+      method: 'create',
+      params: { provider: 'rest' },
+      data: result
+    }
+    console.log(hookBefore.data)
+  })
+})
+
+test('works with simple plan', (t) => {
+  try {
+    validateSchema(schema, ajv)(hookBefore)
+  } catch (err) {
+    if (err.errors) {
+      console.log('validation errors: ', err.errors)
+    }
+    t.fail('validation failed unexpectedly')
+  }
+  t.pass('recipe was validated')
+})

--- a/tasks/util/validateTaskPlan.test.js
+++ b/tasks/util/validateTaskPlan.test.js
@@ -1,13 +1,9 @@
 import test from 'ava'
 import * as mock from '../data/mock'
+import ajv from '../../app/schemas'
 
-const Ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
 const schema = require('../schemas/taskPlan')
-const taskRecipeSchema = require('../schemas/taskRecipe')
-
-let ajv = new Ajv({ $data: true })
-ajv.addSchema([taskRecipeSchema, schema])
 
 let hookBefore
 

--- a/tasks/util/validateTaskRecipe.test.js
+++ b/tasks/util/validateTaskRecipe.test.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import * as mock from '../data/mock'
+import ajv from '../../app/schemas'
 
-const ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
 const schema = require('../schemas/taskRecipe')
 

--- a/tasks/util/validateTaskRecipe.test.js
+++ b/tasks/util/validateTaskRecipe.test.js
@@ -6,20 +6,38 @@ const ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
 const schema = require('../schemas/taskRecipe')
 
-test('create simple recipe', (t) => {
-  const hookBefore = {
+let hookBefore
+
+test.beforeEach(t => {
+  hookBefore = {
     type: 'before',
     method: 'create',
     params: { provider: 'rest' },
     data: taskRecipes.setupSupplier
   }
+})
+
+test('works with simple recipe', (t) => {
   try {
     validateSchema(schema, ajv)(hookBefore)
   } catch (err) {
     if (err.errors) {
       console.log('validation errors: ', err.errors)
     }
-    t.fail('creation failed unexpectedly')
+    t.fail('validation failed unexpectedly')
   }
-  t.pass('recipe was created')
+  t.pass('recipe was validated')
+})
+
+test('fails with incorrect id', (t) => {
+  hookBefore.data.id = 'incorrectId'
+
+  try {
+    validateSchema(schema, ajv)(hookBefore)
+    t.fail('validation passed unexpectedly')
+  } catch (err) {
+    t.deepEqual(err.errors, [
+      "'id' should be equal to one of the allowed values"
+    ])
+  }
 })

--- a/tasks/util/validateTaskRecipe.test.js
+++ b/tasks/util/validateTaskRecipe.test.js
@@ -1,5 +1,5 @@
 import test from 'ava'
-import jsf from 'json-schema-faker'
+import * as mock from '../data/mock'
 
 const ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
@@ -12,7 +12,7 @@ test.beforeEach(t => {
     type: 'before',
     method: 'create',
     params: { provider: 'rest' },
-    data: jsf(schema)
+    data: mock.mockTaskRecipes.finishPrereqs
   }
 })
 

--- a/tasks/util/validateTaskRecipe.test.js
+++ b/tasks/util/validateTaskRecipe.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
-
-import * as taskRecipes from '../data/recipes'
+import jsf from 'json-schema-faker'
 
 const ajv = require('ajv')
 const { validateSchema } = require('feathers-hooks-common')
@@ -13,7 +12,7 @@ test.beforeEach(t => {
     type: 'before',
     method: 'create',
     params: { provider: 'rest' },
-    data: taskRecipes.setupSupplier
+    data: jsf(schema)
   }
 })
 


### PR DESCRIPTION
In this PR:

- added docs to readme explaining json-schema and json-schema-faker
- profile, taskPlan and taskRecipe json schema
- profile story now uses json-faker for mock data (see gif below)
- feathers hook for validating taskPlan and taskRecipe
- tests for feathers validation
- minor bug fixes that were blocking me

Not in this PR

- schemas for models that are not being used by feathers (e.g taskWork)
- dogstack auth schemas 

![mock-profile](https://user-images.githubusercontent.com/1152577/29421870-4d0f834a-836e-11e7-82a1-b6b9474d206a.gif)


closes #118