### PR TITLE
fix `redux-form-validators` error with a fork

### DIFF
--- a/agents/components/Register.js
+++ b/agents/components/Register.js
@@ -7,7 +7,7 @@ import { TextField } from 'redux-form-material-ui'
 import FlatButton from 'material-ui/FlatButton'
 import RaisedButton from 'material-ui/RaisedButton'
 import FontIcon from 'material-ui/FontIcon'
-import { required, email, length, confirmation } from 'redux-form-validators'
+import { required, email, length, confirmation } from '@root-systems/redux-form-validators'
 
 import { FormattedMessage } from '../../lib/Intl'
 import styles from '../styles/Register'

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,14 @@
       "resolved": "https://registry.npmjs.org/@f/is-function/-/is-function-1.1.1.tgz",
       "integrity": "sha1-F9NCpT730v95E3HC9Po4EkXOAjE="
     },
+    "@root-systems/redux-form-validators": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@root-systems/redux-form-validators/-/redux-form-validators-1.1.0.tgz",
+      "integrity": "sha512-gM1fd/kD1Jk38qz+wV5o3WuAXCG4Ol8J1//Zi6Q1TYi6Da0vPvTbgupFB2dpd+kApn4W/Leq9PexXep8U02mCg==",
+      "requires": {
+        "react-intl": "2.3.0"
+      }
+    },
     "@storybook/addon-actions": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@storybook/addon-actions/-/addon-actions-3.2.0.tgz",
@@ -100,7 +108,7 @@
         "deep-equal": "1.0.1",
         "json-stringify-safe": "5.0.1",
         "prop-types": "15.5.10",
-        "react-inspector": "2.1.3",
+        "react-inspector": "2.1.4",
         "uuid": "3.1.0"
       }
     },
@@ -137,25 +145,25 @@
       "dev": true
     },
     "@storybook/react": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.3.tgz",
-      "integrity": "sha1-Tlr/gLYTKCiNz546ayookOq4gL4=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-3.2.4.tgz",
+      "integrity": "sha1-CWpq/MKb3RAoaMSU9PmaP+x/NMo=",
       "dev": true,
       "requires": {
         "@storybook/addon-actions": "3.2.0",
         "@storybook/addon-links": "3.2.0",
         "@storybook/addons": "3.2.0",
         "@storybook/channel-postmessage": "3.2.0",
-        "@storybook/ui": "3.2.3",
+        "@storybook/ui": "3.2.4",
         "airbnb-js-shims": "1.3.0",
         "autoprefixer": "7.1.2",
         "babel-core": "6.25.0",
         "babel-loader": "7.1.1",
-        "babel-plugin-react-docgen": "1.6.0",
+        "babel-plugin-react-docgen": "1.7.0",
         "babel-preset-es2015": "6.24.1",
         "babel-preset-es2016": "6.24.1",
         "babel-preset-react": "6.24.1",
-        "babel-preset-react-app": "3.0.1",
+        "babel-preset-react-app": "3.0.2",
         "babel-preset-stage-0": "6.24.1",
         "babel-runtime": "6.25.0",
         "case-sensitive-paths-webpack-plugin": "2.1.1",
@@ -167,7 +175,7 @@
         "express": "4.15.4",
         "file-loader": "0.11.2",
         "find-cache-dir": "1.0.0",
-        "glamor": "2.20.39",
+        "glamor": "2.20.40",
         "glamorous": "3.25.0",
         "global": "4.3.2",
         "json-loader": "0.5.7",
@@ -188,7 +196,7 @@
         "url-loader": "0.5.9",
         "util-deprecate": "1.0.2",
         "uuid": "3.1.0",
-        "webpack": "3.4.1",
+        "webpack": "3.5.4",
         "webpack-dev-middleware": "1.12.0",
         "webpack-hot-middleware": "2.18.2"
       },
@@ -266,9 +274,9 @@
       }
     },
     "@storybook/ui": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.3.tgz",
-      "integrity": "sha1-lXnBkaFpXT1aqrzvk6elRW2PGa8=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@storybook/ui/-/ui-3.2.4.tgz",
+      "integrity": "sha1-pSsQpfnaryJXCvRX7Hx5IQsKvMM=",
       "dev": true,
       "requires": {
         "@storybook/react-fuzzy": "0.4.0",
@@ -279,6 +287,7 @@
         "global": "4.3.2",
         "json-stringify-safe": "5.0.1",
         "keycode": "2.1.9",
+        "lodash.debounce": "4.0.8",
         "lodash.pick": "4.4.0",
         "lodash.sortby": "4.7.0",
         "mantra-core": "1.7.0",
@@ -286,10 +295,10 @@
         "prop-types": "15.5.10",
         "qs": "6.5.0",
         "react-icons": "2.2.5",
-        "react-inspector": "2.1.3",
+        "react-inspector": "2.1.4",
         "react-komposer": "2.0.0",
         "react-modal": "1.9.7",
-        "react-split-pane": "0.1.65",
+        "react-split-pane": "0.1.66",
         "react-treebeard": "2.0.3",
         "redux": "3.7.2"
       }
@@ -308,7 +317,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.49.tgz",
       "integrity": "sha512-b7mVHoURu1xaP/V6xw1sYwyv9V0EZ7euyi+sdnbnTZxEkAh4/hzPsI6Eflq+ZzHQ/Tgl7l16Jz+0oz8F46MLnA==",
       "requires": {
-        "@types/node": "8.0.19"
+        "@types/node": "8.0.22"
       }
     },
     "@types/mime": {
@@ -317,9 +326,9 @@
       "integrity": "sha512-rek8twk9C58gHYqIrUlJsx8NQMhlxqHzln9Z9ODqiNgv3/s+ZwIrfr+djqzsnVM12xe9hL98iJ20lj2RvCBv6A=="
     },
     "@types/node": {
-      "version": "8.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.19.tgz",
-      "integrity": "sha512-VRQB+Q0L3YZWs45uRdpN9oWr82meL/8TrJ6faoKT5tp0uub2l/aRMhtm5fo68h7kjYKH60f9/bay1nF7ZpTW5g=="
+      "version": "8.0.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.22.tgz",
+      "integrity": "sha512-+YQ5JLlvLP24teVUdUDep83mAWIFoAnOMosrH/2+xDeU9YMUpmMJtYOqVtbivs37h2PL9svz0R3r/MfVuEvEIA=="
     },
     "@types/serve-static": {
       "version": "1.7.31",
@@ -335,7 +344,7 @@
       "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-1.4.29.tgz",
       "integrity": "sha1-hqazqat4z5qQDO74W5totr6oZxI=",
       "requires": {
-        "@types/node": "8.0.19"
+        "@types/node": "8.0.22"
       }
     },
     "accepts": {
@@ -615,7 +624,7 @@
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.0"
       }
@@ -688,11 +697,11 @@
       "integrity": "sha1-++rwfUj9h44Ggr98vurecorbKxg=",
       "dev": true,
       "requires": {
-        "browserslist": "2.3.0",
-        "caniuse-lite": "1.0.30000712",
+        "browserslist": "2.3.3",
+        "caniuse-lite": "1.0.30000715",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
-        "postcss": "6.0.8",
+        "postcss": "6.0.9",
         "postcss-value-parser": "3.3.0"
       }
     },
@@ -1199,9 +1208,9 @@
       }
     },
     "babel-plugin-react-docgen": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.6.0.tgz",
-      "integrity": "sha1-m+NhIbCU2noaO6eRGp6OpLD0TaA=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-docgen/-/babel-plugin-react-docgen-1.7.0.tgz",
+      "integrity": "sha512-0Pw0sdu3W+NfVS048dqMetujQH6gXxCgd2tQGmUmgP/iNNlSbd7aDFj0e8xDmuZQRMy6UNC29zhMpnJJ0xc5BQ==",
       "dev": true,
       "requires": {
         "babel-types": "6.25.0",
@@ -1733,7 +1742,7 @@
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
         "babel-plugin-transform-regenerator": "6.24.1",
-        "browserslist": "2.3.0",
+        "browserslist": "2.3.3",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1816,9 +1825,9 @@
       }
     },
     "babel-preset-react-app": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.0.1.tgz",
-      "integrity": "sha1-i3RMvkf9V8ho5vkTVSzq4mrjGGA=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-3.0.2.tgz",
+      "integrity": "sha512-UwRU1ppOl1JQEXnCXy8aFsKtvSkn1pNQULveOGZsytfrlHUYu9gU+D+zPYY6yMcAtbvQ4hFs+uA0bpPNwR9++Q==",
       "dev": true,
       "requires": {
         "babel-plugin-dynamic-import-node": "1.0.2",
@@ -2046,9 +2055,9 @@
       "integrity": "sha1-LR3DfuWWiGfs6pC22k0W5oYI0h0="
     },
     "binary-extensions": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
-      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
     },
     "bl": {
       "version": "1.2.1",
@@ -2069,9 +2078,9 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "bn.js": {
-      "version": "4.11.7",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
-      "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA=="
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "body": {
       "version": "5.1.0",
@@ -2440,7 +2449,7 @@
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "randombytes": "2.0.5"
       }
     },
@@ -2449,7 +2458,7 @@
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "create-hmac": "1.1.6",
@@ -2467,13 +2476,13 @@
       }
     },
     "browserslist": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.0.tgz",
-      "integrity": "sha512-jDr9Mea+n+FwI+kR0ce7rXCFBoM7hbL80G/th7oPxuNSK4V5J3LPMHB5vykjeI2h7fgSihBbSdoJPmzUC0606Q==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
+      "integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000712",
-        "electron-to-chromium": "1.3.17"
+        "caniuse-lite": "1.0.30000715",
+        "electron-to-chromium": "1.3.18"
       }
     },
     "buf-compare": {
@@ -2522,23 +2531,18 @@
       "dev": true
     },
     "bundle-collapser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/bundle-collapser/-/bundle-collapser-1.2.1.tgz",
-      "integrity": "sha1-4RmvySY45EC5CF9Hrggfp1bLoz0=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bundle-collapser/-/bundle-collapser-1.3.0.tgz",
+      "integrity": "sha1-9LT/WLLyLudwGyD6djBuI/U6P7Y=",
       "requires": {
         "browser-pack": "5.0.1",
         "browser-unpack": "1.2.0",
         "concat-stream": "1.6.0",
-        "falafel": "1.2.0",
+        "falafel": "2.1.0",
         "minimist": "1.2.0",
         "through2": "2.0.3"
       },
       "dependencies": {
-        "acorn": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-          "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
-        },
         "browser-pack": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-5.0.1.tgz",
@@ -2578,17 +2582,6 @@
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
         },
-        "falafel": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-          "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-          "requires": {
-            "acorn": "1.2.2",
-            "foreach": "2.0.5",
-            "isarray": "0.0.1",
-            "object-keys": "1.0.11"
-          }
-        },
         "inline-source-map": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.5.0.tgz",
@@ -2606,11 +2599,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "object-keys": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-          "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
         },
         "readable-stream": {
           "version": "1.1.14",
@@ -2745,7 +2733,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000712",
+        "caniuse-db": "1.0.30000715",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -2756,8 +2744,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000712",
-            "electron-to-chromium": "1.3.17"
+            "caniuse-db": "1.0.30000715",
+            "electron-to-chromium": "1.3.18"
           }
         },
         "lodash.memoize": {
@@ -2769,15 +2757,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000712",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000712.tgz",
-      "integrity": "sha1-iXSDlvnXQZ1fon3ztIhy2tv4MYo=",
+      "version": "1.0.30000715",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000715.tgz",
+      "integrity": "sha1-C5tceVlQ37rzAaiAa6/ofxJtqMo=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000712",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000712.tgz",
-      "integrity": "sha1-tHMt7yRZIk8/eMapuhA6v8xwVnA=",
+      "version": "1.0.30000715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
+      "integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3171,9 +3159,9 @@
       }
     },
     "config": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/config/-/config-1.26.1.tgz",
-      "integrity": "sha1-9kfOMsNF6AunOo6qeppLTlspDKE=",
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/config/-/config-1.26.2.tgz",
+      "integrity": "sha1-JGYpEWjYr64Kroq5nqTUJy9SDK4=",
       "requires": {
         "json5": "0.4.0",
         "os-homedir": "1.0.2"
@@ -3342,7 +3330,7 @@
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "elliptic": "6.4.0"
       }
     },
@@ -3592,7 +3580,7 @@
           "dev": true,
           "requires": {
             "browserslist": "1.7.7",
-            "caniuse-db": "1.0.30000712",
+            "caniuse-db": "1.0.30000715",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
             "postcss": "5.2.17",
@@ -3605,8 +3593,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000712",
-            "electron-to-chromium": "1.3.17"
+            "caniuse-db": "1.0.30000715",
+            "electron-to-chromium": "1.3.18"
           }
         },
         "has-flag": {
@@ -3661,7 +3649,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.27"
       }
     },
     "dashdash": {
@@ -4096,7 +4084,7 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "miller-rabin": "4.0.0",
         "randombytes": "2.0.5"
       }
@@ -4163,13 +4151,13 @@
         "react": "15.6.1",
         "react-dom": "15.6.1",
         "react-hyperscript": "3.0.0",
-        "react-redux": "5.0.5",
+        "react-redux": "5.0.6",
         "react-router-redux": "5.0.0-alpha.6",
         "redux": "3.7.2",
         "redux-fp": "0.2.0",
         "redux-logger": "3.0.6",
         "redux-observable": "0.14.1",
-        "rxjs": "5.4.2",
+        "rxjs": "5.4.3",
         "serve-favicon": "2.4.3",
         "socket.io-client": "2.0.3",
         "standard": "10.0.3",
@@ -4182,12 +4170,11 @@
       },
       "dependencies": {
         "react-redux": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-          "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
+          "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
           "requires": {
-            "create-react-class": "15.6.0",
-            "hoist-non-react-statics": "1.2.0",
+            "hoist-non-react-statics": "2.2.2",
             "invariant": "2.2.2",
             "lodash": "4.17.4",
             "lodash-es": "4.17.4",
@@ -4235,7 +4222,7 @@
         "redux-fp": "0.2.0",
         "redux-observable": "0.14.1",
         "reselect": "3.0.1",
-        "rxjs": "5.4.2"
+        "rxjs": "5.4.3"
       },
       "dependencies": {
         "ajv": {
@@ -4258,11 +4245,6 @@
             "feathers-hooks": "2.0.2",
             "traverse": "0.6.6"
           }
-        },
-        "hoist-non-react-statics": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.2.2.tgz",
-          "integrity": "sha1-wOylp9WijFraMQfrdjsB2mv6gfs="
         },
         "ramda": {
           "version": "0.24.1",
@@ -4398,9 +4380,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.17",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz",
-      "integrity": "sha1-QcE0V8xxZsXBXnZ65h2GqMrN7l0=",
+      "version": "1.3.18",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
+      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
       "dev": true
     },
     "element-class": {
@@ -4414,7 +4396,7 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "brorand": "1.1.0",
         "hash.js": "1.1.3",
         "hmac-drbg": "1.0.1",
@@ -4596,9 +4578,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.26",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.26.tgz",
-      "integrity": "sha1-UbISilMbcMT2dkCTpzy+u4IYY3I=",
+      "version": "0.10.27",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.27.tgz",
+      "integrity": "sha512-3KXJRYzKXTd7xfFy5uZsJCXue55fAYQ035PRjyYk2PicllxIwcW9l3AbM/eGaw3vgVAUW4tl4xg9AXDEI6yw0w==",
       "requires": {
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
@@ -4621,7 +4603,7 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
+        "es5-ext": "0.10.27",
         "es6-symbol": "3.1.1"
       }
     },
@@ -4631,7 +4613,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -4644,7 +4626,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -4662,7 +4644,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.27"
       }
     },
     "es6-weak-map": {
@@ -4671,7 +4653,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26",
+        "es5-ext": "0.10.27",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -4978,7 +4960,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.26"
+        "es5-ext": "0.10.27"
       }
     },
     "events": {
@@ -5209,7 +5191,7 @@
         "ramda": "0.23.0",
         "redux-fp": "0.2.0",
         "redux-observable": "0.14.1",
-        "rxjs": "5.4.2",
+        "rxjs": "5.4.3",
         "typeof-is": "1.0.2"
       }
     },
@@ -5222,18 +5204,17 @@
         "incremental-id": "1.0.0",
         "ramda": "0.23.0",
         "react": "15.6.1",
-        "react-redux": "5.0.5",
+        "react-redux": "5.0.6",
         "recompose": "0.24.0",
         "redux": "3.7.2"
       },
       "dependencies": {
         "react-redux": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-          "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
+          "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
           "requires": {
-            "create-react-class": "15.6.0",
-            "hoist-non-react-statics": "1.2.0",
+            "hoist-non-react-statics": "2.2.2",
             "invariant": "2.2.2",
             "lodash": "4.17.4",
             "lodash-es": "4.17.4",
@@ -5323,7 +5304,7 @@
       "resolved": "https://registry.npmjs.org/feathers-configuration/-/feathers-configuration-0.4.1.tgz",
       "integrity": "sha1-g4TnkvpE7fiVTwLfxXGZ4BACmAM=",
       "requires": {
-        "config": "1.26.1",
+        "config": "1.26.2",
         "debug": "2.6.8"
       }
     },
@@ -5345,9 +5326,9 @@
       }
     },
     "feathers-hooks-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-3.7.0.tgz",
-      "integrity": "sha1-hfZePSkspYwb48dUlCLAAnhSj2w=",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/feathers-hooks-common/-/feathers-hooks-common-3.7.1.tgz",
+      "integrity": "sha1-nV9zmaIG2/k3EOjVIx19jFUFR2U=",
       "requires": {
         "ajv": "5.2.2",
         "debug": "2.6.8",
@@ -5817,9 +5798,9 @@
       }
     },
     "glamor": {
-      "version": "2.20.39",
-      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.39.tgz",
-      "integrity": "sha512-tQ25Rmuad18jybnQgnsBzjhayPaK5Izy7SApBAaRnYQ50uA96SQEAoyymA8QNan51QyK1mB7dFUCX0OyaKa0yg==",
+      "version": "2.20.40",
+      "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
       "dev": true,
       "requires": {
         "fbjs": "0.8.14",
@@ -6133,9 +6114,9 @@
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
     "hoist-non-react-statics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
-      "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.2.2.tgz",
+      "integrity": "sha1-wOylp9WijFraMQfrdjsB2mv6gfs="
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -6311,7 +6292,7 @@
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "ieee754": {
@@ -6624,7 +6605,7 @@
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "requires": {
-        "binary-extensions": "1.9.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -6944,7 +6925,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.1",
+        "node-fetch": "1.7.2",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -7055,6 +7036,11 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
       "integrity": "sha1-8OgK4DmkvWVLXygfyT8EqRSn/M4=",
       "dev": true
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -7689,6 +7675,12 @@
         "react-simple-di": "1.2.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+          "dev": true
+        },
         "react-komposer": {
           "version": "1.13.1",
           "resolved": "https://registry.npmjs.org/react-komposer/-/react-komposer-1.13.1.tgz",
@@ -7854,7 +7846,7 @@
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "brorand": "1.1.0"
       }
     },
@@ -8084,9 +8076,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -8116,7 +8108,7 @@
         "stream-browserify": "2.0.1",
         "stream-http": "2.7.2",
         "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.3",
+        "timers-browserify": "2.0.4",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
         "util": "0.10.3",
@@ -8153,12 +8145,11 @@
           "dev": true
         },
         "timers-browserify": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.3.tgz",
-          "integrity": "sha512-+JAqyNgg+M8+gXIrq2EeUr4kZqRz47Ysco7X5QKRGScRE9HIHckyHD1asozSFGeqx2nmPCgA8T5tIGVO0ML7/w==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+          "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
           "dev": true,
           "requires": {
-            "global": "4.3.2",
             "setimmediate": "1.0.5"
           }
         }
@@ -8750,11 +8741,12 @@
       "dev": true
     },
     "pg": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.1.tgz",
-      "integrity": "sha1-PqvYygVoFEN8dp8X/3oMNqxwI8U=",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-6.4.2.tgz",
+      "integrity": "sha1-w2QBEGDqx6UHoq4GPrhX7OkQ4n8=",
       "requires": {
         "buffer-writer": "1.0.1",
+        "js-string-escape": "1.0.1",
         "packet-reader": "0.3.1",
         "pg-connection-string": "0.1.3",
         "pg-pool": "1.8.0",
@@ -9016,9 +9008,9 @@
       }
     },
     "postcss": {
-      "version": "6.0.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-      "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
+      "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
       "dev": true,
       "requires": {
         "chalk": "2.1.0",
@@ -9412,7 +9404,7 @@
       "integrity": "sha512-0AuD9HG1Ey3/3nqPWu9yqf7rL0KCPu5VgjDsjf5mzEcuo9H/z8nco/fljKgjsOUrZypa95MI0kS4xBZeBzz2lw==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "postcss-load-config": {
@@ -9454,7 +9446,7 @@
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "postcss": "6.0.8",
+        "postcss": "6.0.9",
         "postcss-load-config": "1.2.0",
         "schema-utils": "0.3.0"
       }
@@ -9556,8 +9548,8 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000712",
-            "electron-to-chromium": "1.3.17"
+            "caniuse-db": "1.0.30000715",
+            "electron-to-chromium": "1.3.18"
           }
         },
         "has-flag": {
@@ -9762,7 +9754,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "postcss-modules-local-by-default": {
@@ -9772,7 +9764,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "postcss-modules-scope": {
@@ -9782,7 +9774,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "postcss-modules-values": {
@@ -9792,7 +9784,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.8"
+        "postcss": "6.0.9"
       }
     },
     "postcss-normalize-charset": {
@@ -10338,7 +10330,7 @@
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
       "requires": {
-        "bn.js": "4.11.7",
+        "bn.js": "4.11.8",
         "browserify-rsa": "4.0.1",
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
@@ -10723,9 +10715,9 @@
       }
     },
     "react-inspector": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.1.3.tgz",
-      "integrity": "sha1-YfxMa2sptSYq86rXgaEhOM0YGjI=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-2.1.4.tgz",
+      "integrity": "sha1-ISP6t09orjE2+9AjkvrbdkMm0E0=",
       "dev": true,
       "requires": {
         "babel-runtime": "6.25.0",
@@ -10754,6 +10746,14 @@
         "lodash.pick": "4.4.0",
         "react-stubber": "1.0.0",
         "shallowequal": "0.2.2"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+          "dev": true
+        }
       }
     },
     "react-modal": {
@@ -10781,6 +10781,13 @@
         "lodash": "4.17.4",
         "loose-envify": "1.3.1",
         "prop-types": "15.5.10"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+        }
       }
     },
     "react-router": {
@@ -10797,6 +10804,11 @@
         "warning": "3.0.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -10841,12 +10853,20 @@
       "requires": {
         "babel-runtime": "6.25.0",
         "hoist-non-react-statics": "1.2.0"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs=",
+          "dev": true
+        }
       }
     },
     "react-split-pane": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.65.tgz",
-      "integrity": "sha1-N8C16lyWCCfn82IdChFLD4yciRg=",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/react-split-pane/-/react-split-pane-0.1.66.tgz",
+      "integrity": "sha512-k4F0+BaHkPn0WclipkxEDL18Td2Ocgu+XzhOZznGngWk2l3mB5ujX7jxd5DSa8spHIuCGKQXzgjrk7rc2Y5BUQ==",
       "dev": true,
       "requires": {
         "inline-style-prefixer": "3.0.7",
@@ -11030,6 +11050,11 @@
         "symbol-observable": "1.0.4"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+        },
         "symbol-observable": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
@@ -11127,6 +11152,11 @@
         "query-string": "4.3.4"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+        },
         "prop-types": {
           "version": "15.5.8",
           "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.8.tgz",
@@ -11155,20 +11185,19 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "prop-types": "15.5.10"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz",
+          "integrity": "sha1-qkSM8JhtVcxAdzsXF0t90GbLfPs="
+        }
       }
     },
     "redux-form-material-ui": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/redux-form-material-ui/-/redux-form-material-ui-4.2.0.tgz",
       "integrity": "sha1-HmcJNusI3o5RvUOlX7mWa0ppGp0="
-    },
-    "redux-form-validators": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/redux-form-validators/-/redux-form-validators-1.1.0.tgz",
-      "integrity": "sha1-7zaNrDN2kLCOORRMjhqqyQCiJg4=",
-      "requires": {
-        "react-intl": "2.3.0"
-      }
     },
     "redux-fp": {
       "version": "0.2.0",
@@ -11485,9 +11514,9 @@
       "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
     },
     "rxjs": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
-      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
+      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
       "requires": {
         "symbol-observable": "1.0.4"
       },
@@ -13687,7 +13716,7 @@
         "accepts": "1.3.3",
         "bl": "1.2.1",
         "browserify": "14.4.0",
-        "bundle-collapser": "1.2.1",
+        "bundle-collapser": "1.3.0",
         "create-html": "1.2.0",
         "envify": "4.1.0",
         "first-cache": "1.0.0",
@@ -14051,9 +14080,9 @@
       }
     },
     "webpack": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.4.1.tgz",
-      "integrity": "sha1-TD9PP7MYFVpNsMtqNv8FxWl0GPQ=",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.4.tgz",
+      "integrity": "sha1-VYPrJj7Se3i1vRe/37DrGxzRv4E=",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "redux-devtools-extension": "^2.13.2",
     "redux-form": "^6.6.0",
     "redux-form-material-ui": "^4.2.0",
-    "redux-form-validators": "^1.0.2",
+    "@root-systems/redux-form-validators": "^1.1.0",
     "redux-fp": "^0.2.0",
     "redux-observable": "^0.14.1",
     "reselect": "^3.0.0",


### PR DESCRIPTION
https://github.com/ahdinosaur/redux-form-validators

fixes es module dependency error when run as node

```
/home/thatsmith/github/cobuy/node_modules/redux-form-validators/src/index.js:1
import React from 'react'
^
ParseError: 'import' and 'export' may appear only with 'sourceType: module'
```

@NotThatSmith 