### PR TITLE
fix sqlite3 version to 3.1.8 to avoid other module install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,6 @@
     "deep-freeze": "^0.0.1",
     "dependency-check": "^2.8.0",
     "precinct": "^3.6.0",
-    "sqlite3": "^3.1.8"
+    "sqlite3": "3.1.8"
   }
 }


### PR DESCRIPTION
easy