### PR TITLE
dashboard only requests taskPlans and taskWorks of currentAgent

### DIFF
--- a/app/containers/Dashboard.js
+++ b/app/containers/Dashboard.js
@@ -39,6 +39,7 @@ export default connect({
   },
   shouldQueryAgain: (props, status) => {
     const { currentAgent, taskPlans } = props.selected
+    if (status.isPending) return false
     if (currentAgent && isEmpty(taskPlans)) return true
     return false
   }

--- a/app/containers/Dashboard.js
+++ b/app/containers/Dashboard.js
@@ -1,4 +1,5 @@
 import { connect } from 'feathers-action-react'
+import { isEmpty } from 'ramda'
 
 import Dashboard from '../components/Dashboard'
 import { actions as taskPlanActions } from '../../tasks/dux/plans'
@@ -13,14 +14,32 @@ export default connect({
     taskWorks: taskWorkActions,
     orders: orderActions
   },
-  query: [
-    {
-      service: 'taskPlans',
-      params: {}
-    },
-    {
-      service: 'taskWorks',
-      params: {}
+  query: (props) => {
+    var queries = []
+    const { currentAgent } = props.selected
+    if (currentAgent) {
+      queries.push({
+        service: 'taskPlans',
+        params: {
+          query: {
+            assigneeId: currentAgent.id
+          }
+        }
+      })
+      queries.push({
+        service: 'taskWorks',
+        params: {
+          query: {
+            workerAgentId: currentAgent.id
+          }
+        }
+      })
     }
-  ]
+    return queries
+  },
+  shouldQueryAgain: (props, status) => {
+    const { currentAgent, taskPlans } = props.selected
+    if (currentAgent && isEmpty(taskPlans)) return true
+    return false
+  }
 })(Dashboard)


### PR DESCRIPTION
Previously when loading the dashboard, all `taskPlans` and `taskWorks` in the database would be loaded and displayed - even those that don't belong to the current user. Now only those that belong to the current user are loaded.

In the future we will want to protect the routes themselves against unauthorised data access.

closes #213 