### PR TITLE
each different use of Profile provides a different string for '{agent…

### DIFF
--- a/agents/components/Profile.js
+++ b/agents/components/Profile.js
@@ -11,7 +11,7 @@ import styles from '../styles/Profile'
 import AvatarField from '../../app/components/AvatarField'
 
 function Profile (props) {
-  const { styles, isEditing, toggleEdit, updateProfile, handleSubmit } = props
+  const { styles, isEditing, toggleEdit, updateProfile, handleSubmit, agentType } = props
 
   const updateProfileAndToggleEdit = (nextProfile) => {
     toggleEdit()
@@ -27,7 +27,10 @@ function Profile (props) {
     }, [
       h(FormattedMessage, {
         id: 'agents.profile',
-        className: styles.labelText
+        className: styles.labelText,
+        values: {
+          agentType
+        }
       })
     ]),
     h('div', {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -26,7 +26,7 @@
   "agents.signInWith": "sign in with...",
   "agents.saveAvatar": "save avatar",
   "agents.editAvatar": "edit avatar",
-  "agents.profile": "my profile",
+  "agents.profile": "{agentType} profile",
   "agents.memberInvites": "invite your members",
   "agents.inviteMembers": "invite members",
   "agents.member": "member",

--- a/tasks/components/CreateProfileTask.js
+++ b/tasks/components/CreateProfileTask.js
@@ -14,6 +14,7 @@ export default (props) => {
     initialValues: currentAgent.profile,
     updateProfile: (nextProfile) => {
       actions.profiles.update(currentAgent.profile.id, nextProfile)
-    }
+    },
+    agentType: 'my'
   })
 }

--- a/tasks/components/SetupGroupTask.js
+++ b/tasks/components/SetupGroupTask.js
@@ -34,7 +34,8 @@ export default (props) => {
         initialValues: profile,
         updateProfile: (nextProfile) => {
           actions.profiles.update(profile.id, merge(nextProfile, { agentId: consumerAgent.id }))
-        }
+        },
+        agentType: 'group'
       })
     },
     {

--- a/tasks/components/SetupSupplierTask.js
+++ b/tasks/components/SetupSupplierTask.js
@@ -21,7 +21,8 @@ export default (props) => {
         initialValues: profile,
         updateProfile: (nextProfile) => {
           actions.profiles.update(profile.id, merge(nextProfile, { agentId: supplierAgent.id }))
-        }
+        },
+        agentType: 'supplier'
       })
     },
     {


### PR DESCRIPTION
…Type} Profile'

Fixes using the `Profile` component and being stuck with "My Profile" header text - now instead of "My" we have either "Group", "Supplier" or "My" depending on which profile you are filling out.

closes #206 