### PR TITLE
use a temp wrapped Switch to address react-router-redux bug until ups…

### DIFF
--- a/app/components/Layout.js
+++ b/app/components/Layout.js
@@ -1,8 +1,10 @@
 import h from 'react-hyperscript'
 import { compose } from 'recompose'
 import { connect as connectFela } from 'react-fela'
-import { Route, Switch } from 'react-router-dom'
+import { Route } from 'react-router-dom'
 import { pipe, map, values, isNil } from 'ramda'
+
+import ConnectedSwitch from '../../lib/connected-Switch'
 
 import styles from '../styles/Layout'
 
@@ -20,7 +22,7 @@ function Layout (props) {
       className: styles.container
     }, [
       h(Nav, { navigationRoutes }),
-      h(Switch, {}, [
+      h(ConnectedSwitch, {}, [
         mapRoutePages(routes)
       ])
     ])

--- a/lib/connected-Switch.js
+++ b/lib/connected-Switch.js
@@ -1,0 +1,11 @@
+// TODO: IK: this is a temp component to address issues with react-router-redux 5.0.0-alpha.6
+// with normal Switch, keeping location state in sync with the URL is problematic
+// see here https://github.com/ReactTraining/react-router/issues/5072
+import { connect } from 'react-redux'
+import { Switch } from 'react-router'
+
+const ConnectedSwitch = connect((state) => {
+  return { location: state.router.location }
+})(Switch)
+
+export default ConnectedSwitch


### PR DESCRIPTION
…tream fix

addresses not always being able to navigate back in history with the back button
see [this discussion](https://github.com/ReactTraining/react-router/issues/5072) for explanations.

this solution is temporary, to be replaced when `react-router-redux` sorts it out

closes #196 