### PR TITLE
Feature/tapin demo seed data

### DIFF
--- a/db/seeds/a_reset-db.js
+++ b/db/seeds/a_reset-db.js
@@ -1,0 +1,8 @@
+exports.seed = function (knex, Promise) {
+  return Promise.all([
+    knex('taskPlans').del(),
+    knex('agents').del(),
+    knex('credentials').del(),
+    knex('profiles').del()
+  ])
+}

--- a/db/seeds/dev.js
+++ b/db/seeds/dev.js
@@ -1,42 +1,33 @@
 const hasher = require('feathers-authentication-local/lib/utils/hash')
 
 exports.seed = function (knex, Promise) {
-  // delete ALL existing entries
-  return Promise.all([
-    knex('taskPlans').del(),
-    knex('agents').del(),
-    knex('credentials').del(),
-    knex('profiles').del()
-  ])
-    .then(() => {
-      // insert person agent
-      const devPersonAgent = {}
-      return knex('agents').insert(devPersonAgent).returning('id')
-    })
-    .then(([agentId]) => {
-      // insert person profile
-      const devPersonProfile = {
-        agentId,
-        name: 'Alice',
-        description: 'Hey, This is only a test.',
-        avatar: 'https://i.imgur.com/9p2dC14.gif' // source: https://imgur.com/gallery/OlVVE
-      }
-      return Promise.all([
-        Promise.resolve(agentId),
-        knex('profiles').insert(devPersonProfile)
-      ])
-    })
-    .then(([agentId]) => {
-      // insert person credential
-      const devPersonCredential = {
-        agentId,
-        email: 'test@test.nz',
-        password: 'password'
-      }
-      return hashCredential(devPersonCredential)
-    }).then(credential => {
-      return knex('credentials').insert(credential)
-    })
+  // insert person agent
+  const devPersonAgent = {}
+  return knex('agents').insert(devPersonAgent).returning('id')
+  .then(([agentId]) => {
+    // insert person profile
+    const devPersonProfile = {
+      agentId,
+      name: 'Alice',
+      description: 'Hey, This is only a test.',
+      avatar: 'https://i.imgur.com/9p2dC14.gif' // source: https://imgur.com/gallery/OlVVE
+    }
+    return Promise.all([
+      Promise.resolve(agentId),
+      knex('profiles').insert(devPersonProfile)
+    ])
+  })
+  .then(([agentId]) => {
+    // insert person credential
+    const devPersonCredential = {
+      agentId,
+      email: 'test@test.nz',
+      password: 'password'
+    }
+    return hashCredential(devPersonCredential)
+  }).then(credential => {
+    return knex('credentials').insert(credential)
+  })
 }
 
 function hashCredential (credential) {

--- a/db/seeds/tapin-demo.js
+++ b/db/seeds/tapin-demo.js
@@ -1,0 +1,73 @@
+const hasher = require('feathers-authentication-local/lib/utils/hash')
+const { flatten, map, pick, merge } = require('ramda')
+
+const agents = [
+  {
+    name: 'Dan Lewis',
+    description: "I'm Dan - I love building things, from sheds to organisations",
+    avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/dan.png',
+    email: 'dan@rootsystems.nz',
+    password: 'password'
+  },
+  {
+    name: 'Iain Kirkpatrick',
+    description: "I'm Iain - I love basketball and programming while watching basketball",
+    avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/iain.png',
+    email: 'iain@rootsystems.nz',
+    password: 'password'
+  },
+  {
+    name: 'Sarah Rogers',
+    description: "I'm Sarah - I love bargain hunting and adding to my vast repertoire of Simpsons knowledge",
+    avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/sarah.png',
+    email: 'sarah@rootsystems.nz',
+    password: 'password'
+  },
+  {
+    name: 'Mikey Williams',
+    description: "I'm Mikey - I love making mad science and participating in cooperative ecosystems",
+    avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/mikey.png',
+    email: 'mikey@rootsystems.nz',
+    password: 'password'
+  }
+]
+
+exports.seed = function (knex, Promise) {
+  // insert agents
+  const devPersonAgent = {}
+  return Promise.all([
+    knex('agents').insert(devPersonAgent).returning('id'),
+    knex('agents').insert(devPersonAgent).returning('id'),
+    knex('agents').insert(devPersonAgent).returning('id'),
+    knex('agents').insert(devPersonAgent).returning('id')
+  ])
+  .then((ids) => {
+    ids = flatten(ids)
+    // insert person profile
+    return Promise.all(agents.map((agent, i) => {
+      const profile = merge(pick(['name', 'description', 'avatar'], agent), { agentId: ids[i] })
+      return knex('profiles').insert(profile).returning('agentId')
+    }))
+  })
+  .then((ids) => {
+    ids = flatten(ids)
+    // hash person credential
+    return Promise.all(agents.map((agent, i) => {
+      const credential = merge(pick(['email', 'password'], agent), { agentId: ids[i] })
+      return hashCredential(credential)
+    }))
+  })
+  .then((credentials) => {
+    // insert person credential
+    return Promise.all(credentials.map((credential) => {
+      return knex('credentials').insert(credential).returning('agentId')
+    }))
+  })
+}
+
+function hashCredential (credential) {
+  return hasher(credential.password)
+    .then(hashedPassword => {
+      return Object.assign(credential, { password: hashedPassword })
+    })
+}

--- a/db/seeds/tapin-demo.js
+++ b/db/seeds/tapin-demo.js
@@ -40,6 +40,13 @@ const agents = [
     avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/mikey.png',
     email: 'mikey@rootsystems.nz',
     password: 'password'
+  },
+  {
+    name: 'Michael Smith',
+    description: "I'm Michael - I love exploring the globe and wearing radical socks",
+    avatar: 'https://raw.githubusercontent.com/root-systems/handbook/master/members/michael.png',
+    email: 'michael@rootsystems.nz',
+    password: 'password'
   }
 ]
 
@@ -72,6 +79,7 @@ exports.seed = function (knex, Promise) {
     // insert agents
     const devPersonAgent = {}
     return Promise.all([
+      knex('agents').insert(devPersonAgent).returning('id'),
       knex('agents').insert(devPersonAgent).returning('id'),
       knex('agents').insert(devPersonAgent).returning('id'),
       knex('agents').insert(devPersonAgent).returning('id'),

--- a/db/seeds/tapin-demo.js
+++ b/db/seeds/tapin-demo.js
@@ -188,15 +188,26 @@ exports.seed = function (knex, Promise) {
     .then(() => ids)
   })
   .then((ids) => {
-    // insert person relationships
+    // insert member relationships
     return Promise.all(agents.map((agent, i) => {
       const relationship = {
-        relationshipType: i === 0 ? 'admin' : 'member',
+        relationshipType: 'member',
         sourceId: groupId,
         targetId: ids[i]
       }
       return knex('relationships').insert(relationship).returning('agentId')
     }))
+    // not sure why, but relationships .returning doesn't return the correct agentIds, hack for now
+    .then(() => ids)
+  })
+  .then((ids) => {
+    // insert admin relationship for first group member
+    const relationship = {
+      relationshipType: 'admin',
+      sourceId: groupId,
+      targetId: ids[0]
+    }
+    return knex('relationships').insert(relationship)
   })
 }
 


### PR DESCRIPTION
Adds seed data for the upcoming Tapin demo:

- group
- supplier to the group
- members, including a group admin, which belong to the group
- products (resourceTypes, products, and priceSpecs) that the supplier supplies

The idea is that we can record a demo video without needing to go through and invite new members, write a bunch of product data each time - we can just log in as the various members on browsers and demonstrate the ordering / intent casting functionality.

closes #252 
