### PR TITLE
fix storybook

### DIFF
--- a/agents/dux/invited.js
+++ b/agents/dux/invited.js
@@ -3,7 +3,7 @@ import createAction from '@f/create-action'
 import { push } from 'react-router-redux'
 
 import { combineEpics } from 'redux-observable'
-import Rx from 'rxjs'
+import { Observable } from 'rxjs'
 
 import { actions as tokenConsumes } from '../../tokens/dux/tokenConsumes'
 import { authentication } from 'dogstack-agents/actions'
@@ -34,12 +34,12 @@ export function patchPasswordAndSignIn (action$, store, { feathers }) {
       const password = payload.password
       const patchPasswordPayload = { jwt: payload.jwt, payload: { data: { password } } }
 
-      return Rx.Observable.merge(
-        Rx.Observable.of(tokenConsumes.create(cid, patchPasswordPayload)),
+      return Observable.merge(
+        Observable.of(tokenConsumes.create(cid, patchPasswordPayload)),
         tokenConsumesComplete$
           .withLatestFrom(tokenConsumesSet$, (success, set) => set.payload.data)
           .mergeMap(({ result: { email } }) => {
-            return Rx.Observable.of(authentication.signIn(cid, { strategy: 'local', email, password }))
+            return Observable.of(authentication.signIn(cid, { strategy: 'local', email, password }))
           }),
         signInSuccess$.mapTo(push('/')) // TODO this should be configurable
       )

--- a/config/default.js
+++ b/config/default.js
@@ -1,9 +1,4 @@
-const { pipe, path, toPairs, reduce, assocPath } = require('ramda')
 const deepExtend = require('deep-extend')
-
-const browserConfigPaths = [
-  'assetsUrl'
-]
 
 var config = {
   port: 3000,
@@ -23,6 +18,15 @@ var config = {
   }
 }
 
+/*
+
+const browserConfigPaths = [
+  'assetsUrl'
+]
+
+// this breaks webpack in storybook, wtf?
+// https://github.com/webpack/webpack/issues/4039
+
 const getBrowserConfig = pipe(
   toPairs,
   reduce((sofar, [key]) => {
@@ -32,6 +36,11 @@ const getBrowserConfig = pipe(
 )
 
 config.browser = getBrowserConfig(config)
+*/
+
+config.browser = {
+  browserConfigPaths: config.browserConfigPaths
+}
 
 module.exports = deepExtend(
   config,


### PR DESCRIPTION
this pull request fixes storybook. ~it also breaks the app, so don't merge.~

~but feel free to use and update this branch whenever you want to use storybook.~

~will need to investigate a proper fix. the problem is due to https://github.com/webpack/webpack/issues/3997 in `config/default.js`, which seems strange because it never uses `import`. it also can't use `import` and `export` because in the app it's loaded by [`node-config`](https://github.com/lorenwest/node-config) which doesn't understand ES modules.~