### PR TITLE
WIP: Chore/postgres local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,34 @@ Anything that a developer working on Cobuy should know about.
 
 TODO organize all the miscy mushy magic
 
+### Postgres DEV setup
+
+Use a [`~/.pgpass`](https://www.postgresql.org/docs/current/static/libpq-pgpass.html) file to automate your passwords!
+
+```shell
+echo "localhost:5432:*:postgres:password" > ~/.pgpass
+chmod 600 ~/.pgpass
+```
+
+Create your database with:
+
+```shell
+createdb cobuy_development -h localhost -U postgres
+```
+
+Drop your database with:
+
+
+```shell
+dropdb cobuy_development -h localhost -U postgres
+```
+
+Connect to your database with:
+
+```shell
+psql -h localhost -U postgres -d cobuy_development
+```
+
 ### How to get private development config
 
 Our development config is stored in a private repository:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Before we start, please
 
 - [install `node@8` and `npm@5`](https://dogstack.js.org/guides/how-to-install-js.html)
 - [install Git LFS](https://git-lfs.github.com/)
+- [install and set up Postgres for your system](https://dogstack.js.org/guides/how-to-setup-sql-db.html)
+- create a database in Postgres named `cobuy_development` (i.e. using a command like `CREATE DATABASE cobuy_development;` in `psql`)
 
 ```shell
 git lfs install

--- a/db/index.js
+++ b/db/index.js
@@ -13,7 +13,8 @@ module.exports = {
     client: 'postgresql',
     connection: {
       host: 'localhost',
-      user: "postgres",
+      user: 'postgres',
+      password: 'password',
       database: 'cobuy_development'
     }
   },

--- a/db/index.js
+++ b/db/index.js
@@ -10,11 +10,12 @@ module.exports = {
   },
 
   development: {
-    client: 'sqlite3',
+    client: 'postgresql',
     connection: {
-      filename: join(__dirname, 'dev.sqlite')
-    },
-    useNullAsDefault: true
+      host: 'localhost',
+      user: "postgres",
+      database: 'cobuy_development'
+    }
   },
 
   test: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db": "dog db",
     "storybook": "start-storybook -p 6006",
     "burnthemall": "rm -rf package-lock.json node_modules; npm i",
-    "burnthedb": "rm db/dev.sqlite; dog db migrate:latest; dog db seed:run"
+    "burnthedb": "dropdb cobuy_development -h localhost -U postgres; createdb cobuy_development -h localhost -U postgres; dog db migrate:latest; dog db seed:run"
   },
   "browserify": {
     "transform": [

--- a/tasks/services/works.js
+++ b/tasks/services/works.js
@@ -222,14 +222,17 @@ function createCastOrderIntentTaskWorks (hook) {
       // TODO: IK: feels like a pretty sub-optimal way of querying, probably makes sense to have orderId as it's own column
       return taskPlans.find({
         query: {
-          taskRecipeId: 'castIntent',
-          params: {
-            $like: `%"orderId":${orderId}%`
-          }
+          taskRecipeId: 'castIntent'
+          // TODO: IK: can't compare JSON values in postgres, need another way to do it
+          // params: {
+          //   $like: `%"orderId":${orderId}%`
+          // }
         }
       })
         .then((taskPlans) => {
-          return Promise.all(taskPlans.map((taskPlan) => {
+          // TODO: IK: can't compare JSON values in postgres, need another way to do it
+          const currentOrderTaskPlans = filter((plan) => { return plan.params.orderId === orderId }, taskPlans)
+          return Promise.all(currentOrderTaskPlans.map((taskPlan) => {
             const { id, taskRecipeId, assigneeId, params } = taskPlan
             return taskWorks.create({
               taskPlanId: id,


### PR DESCRIPTION
closes #289 

todo:
- [X] connection params to use postgres rather than sqlite
- [x] guide for macOS and Linux users

NB. currently running the app assumes you have a database in your local Postgres installation named `cobuy_development`. The guide will show users how to create this db, but could also be cool if possible to have an npm script (`npm run init`?) that does that, plus migrate, seed etc for them