### PR TITLE
Dashboard only show current agents orders

### DIFF
--- a/agents/getters/getCurrentAgentGroupIds.js
+++ b/agents/getters/getCurrentAgentGroupIds.js
@@ -7,7 +7,7 @@ import getCurrentAgent from 'dogstack-agents/agents/getters/getCurrentAgent'
 const getCurrentAgentGroupIds = createSelector(
   getCurrentAgent,
   (currentAgent) => {
-    if (!currentAgent) return null
+    if (!currentAgent) return []
     return map(prop('agentId'), currentAgent.groups)
   }
 )

--- a/ordering/getters/getOrdersByCurrentAgent.js
+++ b/ordering/getters/getOrdersByCurrentAgent.js
@@ -1,0 +1,21 @@
+import { createSelector } from 'reselect'
+import { filter, contains } from 'ramda'
+
+import getCurrentAgentGroupIds from '../../agents/getters/getCurrentAgentGroupIds'
+import getCurrentAgentId from 'dogstack-agents/agents/getters/getCurrentAgentId'
+import getOrders from './getOrders'
+
+const getOrdersByCurrentAgent = createSelector(
+  getCurrentAgentGroupIds,
+  getOrders,
+  getCurrentAgentId,
+  (groupIds, orders, currentAgentId) => {
+    return filter((order) => {
+      const { adminAgentId, consumerAgentId } = order
+      return (adminAgentId === currentAgentId || contains(consumerAgentId, groupIds))
+    }, orders
+    )
+  }
+)
+
+export default getOrdersByCurrentAgent

--- a/ordering/getters/getOrdersPageProps.js
+++ b/ordering/getters/getOrdersPageProps.js
@@ -1,13 +1,13 @@
 import { createStructuredSelector } from 'reselect'
 import getCurrentAgent from 'dogstack-agents/agents/getters/getCurrentAgent'
 
-import getOrders from './getOrders'
 import getActiveParentTaskPlans from '../../tasks/getters/getActiveParentTaskPlans'
+import getOrdersByCurrentAgent from './getOrdersByCurrentAgent'
 
 const getOrdersPageProps = createStructuredSelector({
   currentAgent: getCurrentAgent,
   taskPlans: getActiveParentTaskPlans,
-  orders: getOrders
+  orders: getOrdersByCurrentAgent
 })
 
 export default getOrdersPageProps


### PR DESCRIPTION
Shows orders on the dashboard if the user is an admin or if the order is from a group they are a member of.

May still need to update query in container to fetch only related orders instead of all orders

fixes #312