### PR TITLE
WIP: Anywhere Order Summary

### DIFF
--- a/ordering/components/OrderSummary.js
+++ b/ordering/components/OrderSummary.js
@@ -2,7 +2,7 @@ import { compose } from 'recompose'
 import { connect as connectFela } from 'react-fela'
 import h from 'react-hyperscript'
 import Paper from 'material-ui/Paper'
-import { groupBy, map, pipe, values, isNil } from 'ramda'
+import { groupBy, map, pipe, values, isNil, isEmpty } from 'ramda'
 import {
   Table,
   TableHeader,
@@ -14,7 +14,9 @@ import { FormattedMessage } from '../../lib/Intl'
 import AgentOrderSummary from './AgentOrderSummary'
 
 function OrderSummary (props) {
-  const { currentOrderOrderPlansByAgent, currentOrder } = props
+  const { currentOrderOrderPlansByAgent, currentOrder, currentOrderOrderIntentsByAgent } = props
+  const orderInfoByAgent = !isEmpty(currentOrderOrderPlansByAgent) ? currentOrderOrderPlansByAgent
+                                                                   : currentOrderOrderIntentsByAgent
 
   // all the plans grouped by agent, may be > 1 per agent
   // const groupedAgentPlans = groupBy((plan) => plan.agent.profile.id)(order.orderPlans)
@@ -50,7 +52,7 @@ function OrderSummary (props) {
           ])
         ])
       ]),
-      renderOrderPlansByAgent(values(currentOrderOrderPlansByAgent))
+      renderOrderPlansByAgent(values(orderInfoByAgent))
     ])
   )
 }

--- a/ordering/getters/getCurrentOrderOrderIntents.js
+++ b/ordering/getters/getCurrentOrderOrderIntents.js
@@ -1,0 +1,11 @@
+import { createSelector } from 'reselect'
+import { prop } from 'ramda'
+
+import getOrderIntentsByOrderId from './getOrderIntentsByOrderId'
+import getCurrentOrderId from './getCurrentOrderId'
+
+export default createSelector(
+  getCurrentOrderId,
+  getOrderIntentsByOrderId,
+  prop
+)

--- a/ordering/getters/getCurrentOrderOrderIntentsByAgent.js
+++ b/ordering/getters/getCurrentOrderOrderIntentsByAgent.js
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect'
+import { groupBy, prop, pipe, values } from 'ramda'
+
+import getCurrentOrderOrderIntents from './getCurrentOrderOrderIntents'
+
+export default createSelector(
+  getCurrentOrderOrderIntents,
+  pipe(
+    values,
+    groupBy(prop('agentId'))
+  )
+)

--- a/ordering/getters/getOrderIntents.js
+++ b/ordering/getters/getOrderIntents.js
@@ -1,3 +1,20 @@
-const getOrderIntents = (state) => state.orderIntents
+import { createSelector } from 'reselect'
+import { map, merge } from 'ramda'
 
-export default getOrderIntents
+import getRawOrderIntents from './getRawOrderIntents'
+import getPriceSpecs from '../../supply/getters/getPriceSpecs'
+import getProducts from '../../supply/getters/getProducts'
+import { getAgents } from 'dogstack-agents/getters'
+
+export default createSelector(
+  getRawOrderIntents,
+  getPriceSpecs,
+  getProducts,
+  getAgents,
+  (orderIntents, priceSpecs, products, agents) => {
+    return map((orderIntent) => {
+      const { priceSpecId, agentId, productId } = orderIntent
+      return merge(orderIntent, { priceSpec: priceSpecs[priceSpecId], agent: agents[agentId], product: products[productId] })
+    }, orderIntents)
+  }
+)

--- a/ordering/getters/getOrderIntentsByOrderId.js
+++ b/ordering/getters/getOrderIntentsByOrderId.js
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect'
+import { values, pipe, groupBy, prop } from 'ramda'
+
+import getOrderIntents from './getOrderIntents'
+
+export default createSelector(
+  getOrderIntents,
+  pipe(
+    values,
+    groupBy(prop('orderId'))
+  )
+)

--- a/ordering/getters/getRawOrderIntents.js
+++ b/ordering/getters/getRawOrderIntents.js
@@ -1,0 +1,3 @@
+import { prop } from 'ramda'
+
+export default prop('orderIntents')

--- a/tasks/components/ViewOrderSummaryTask.js
+++ b/tasks/components/ViewOrderSummaryTask.js
@@ -11,12 +11,13 @@ import anyOrderPlansMissingAgentProfiles from '../util/anyOrderPlansMissingAgent
 import anyOrderPlansMissingProductResourceTypes from '../util/anyOrderPlansMissingProductResourceTypes'
 
 export default (props) => {
-  const { currentOrderOrderPlansByAgent } = props
+  console.log('order summary task props is: ', props)
+  const { currentOrderOrderPlansByAgent, currentOrderOrderIntentsByAgent } = props
   if (isEmpty(currentOrderOrderPlansByAgent)) return null
-  if (anyOrderPlansMissingPriceSpecs(currentOrderOrderPlansByAgent)) return null
-  if (anyOrderPlansMissingAgents(currentOrderOrderPlansByAgent)) return null
-  if (anyOrderPlansMissingProducts(currentOrderOrderPlansByAgent)) return null
-  if (anyOrderPlansMissingAgentProfiles(currentOrderOrderPlansByAgent)) return null
-  if (anyOrderPlansMissingProductResourceTypes(currentOrderOrderPlansByAgent)) return null
+  if (anyOrderPlansMissingPriceSpecs(currentOrderOrderPlansByAgent) && anyOrderPlansMissingPriceSpecs(currentOrderOrderIntentsByAgent)) return null
+  if (anyOrderPlansMissingAgents(currentOrderOrderPlansByAgent) && anyOrderPlansMissingAgents(currentOrderOrderIntentsByAgent)) return null
+  if (anyOrderPlansMissingProducts(currentOrderOrderPlansByAgent) && anyOrderPlansMissingProducts(currentOrderOrderIntentsByAgent)) return null
+  if (anyOrderPlansMissingAgentProfiles(currentOrderOrderPlansByAgent) && anyOrderPlansMissingAgentProfiles(currentOrderOrderIntentsByAgent)) return null
+  if (anyOrderPlansMissingProductResourceTypes(currentOrderOrderPlansByAgent) && anyOrderPlansMissingProductResourceTypes(currentOrderOrderIntentsByAgent)) return null
   return h(OrderSummary, props)
 }

--- a/tasks/components/ViewOrderSummaryTask.js
+++ b/tasks/components/ViewOrderSummaryTask.js
@@ -11,9 +11,9 @@ import anyOrderPlansMissingAgentProfiles from '../util/anyOrderPlansMissingAgent
 import anyOrderPlansMissingProductResourceTypes from '../util/anyOrderPlansMissingProductResourceTypes'
 
 export default (props) => {
-  console.log('order summary task props is: ', props)
+  console.log('view order summary task props is: ', props)
   const { currentOrderOrderPlansByAgent, currentOrderOrderIntentsByAgent } = props
-  if (isEmpty(currentOrderOrderPlansByAgent)) return null
+  if (isEmpty(currentOrderOrderPlansByAgent) && isEmpty(currentOrderOrderIntentsByAgent)) return null
   if (anyOrderPlansMissingPriceSpecs(currentOrderOrderPlansByAgent) && anyOrderPlansMissingPriceSpecs(currentOrderOrderIntentsByAgent)) return null
   if (anyOrderPlansMissingAgents(currentOrderOrderPlansByAgent) && anyOrderPlansMissingAgents(currentOrderOrderIntentsByAgent)) return null
   if (anyOrderPlansMissingProducts(currentOrderOrderPlansByAgent) && anyOrderPlansMissingProducts(currentOrderOrderIntentsByAgent)) return null

--- a/tasks/containers/ViewOrderSummaryTask.js
+++ b/tasks/containers/ViewOrderSummaryTask.js
@@ -33,6 +33,8 @@ export default compose(
       const { taskPlan, selected } = props
       const { currentOrderOrderPlansByAgent, currentOrderOrderIntentsByAgent } = selected
 
+      console.log('selected on query is: ', selected)
+
       // order has been commited/closed if order plans exist
       const orderInfoByAgent = !isEmpty(currentOrderOrderPlansByAgent) ? currentOrderOrderPlansByAgent
                                                                        : currentOrderOrderIntentsByAgent
@@ -80,8 +82,8 @@ export default compose(
           }
         })
       }
-
       if (!isEmpty(orderInfoByAgent)) {
+        console.log('orderInfo is not empty')
         queries.push({
           service: 'priceSpecs',
           params: {
@@ -156,19 +158,20 @@ export default compose(
       const { taskPlan } = props.ownProps
       const { currentOrderOrderPlansByAgent, currentOrderOrderIntentsByAgent } = props.selected
 
-      // wait for task plan before re-query
-      if (isNil(taskPlan)) return false
-
       console.log('orderPlans: ', currentOrderOrderPlansByAgent)
       console.log('orderIntents: ', currentOrderOrderIntentsByAgent)
 
+      // wait for task plan before re-query
+      if (isNil(taskPlan)) return false
+
+      console.log('is everything empty?: ', (isEmpty(currentOrderOrderPlansByAgent) && isEmpty(currentOrderOrderIntentsByAgent)))
       if (isEmpty(currentOrderOrderPlansByAgent) && isEmpty(currentOrderOrderIntentsByAgent)) return true
       if (anyOrderPlansMissingPriceSpecs(currentOrderOrderPlansByAgent) && anyOrderPlansMissingPriceSpecs(currentOrderOrderIntentsByAgent)) return true
       if (anyOrderPlansMissingAgents(currentOrderOrderPlansByAgent) && anyOrderPlansMissingAgents(currentOrderOrderIntentsByAgent)) return true
       if (anyOrderPlansMissingProducts(currentOrderOrderPlansByAgent) && anyOrderPlansMissingProducts(currentOrderOrderIntentsByAgent)) return true
       if (anyOrderPlansMissingAgentProfiles(currentOrderOrderPlansByAgent) && anyOrderPlansMissingAgentProfiles(currentOrderOrderIntentsByAgent)) return true
       if (anyOrderPlansMissingProductResourceTypes(currentOrderOrderPlansByAgent) && anyOrderPlansMissingProductResourceTypes(currentOrderOrderIntentsByAgent)) return true
-
+      
       return false
     }
   })

--- a/tasks/getters/getViewOrderSummaryTaskProps.js
+++ b/tasks/getters/getViewOrderSummaryTaskProps.js
@@ -1,8 +1,10 @@
 import { createStructuredSelector } from 'reselect'
 import getCurrentOrderOrderPlansByAgent from '../../ordering/getters/getCurrentOrderOrderPlansByAgent'
+import getCurrentOrderOrderIntentsByAgent from '../../ordering/getters/getCurrentOrderOrderIntentsByAgent'
 import getCurrentOrder from '../../ordering/getters/getCurrentOrder'
 
 export default createStructuredSelector({
   currentOrderOrderPlansByAgent: getCurrentOrderOrderPlansByAgent,
-  currentOrder: getCurrentOrder
+  currentOrder: getCurrentOrder,
+  currentOrderOrderIntentsByAgent: getCurrentOrderOrderIntentsByAgent
 })


### PR DESCRIPTION
Before this PR order summary uses `orderPlans` to show what users have ordered. `orderPlans` are only created when an order is closed. We use `orderIntents` until then.
`orderIntents` and `orderPlans` have the same data shape, so this PR should hopefully be as easy as switching `orderPlans with `orderIntents` when an order is still open.

Currently, this doesn't work for open orders. I suspect the problem to be in the `shouldQueryAgain` checks. There's also some renaming of functions that need to happen as most util functions now accept both `orderPlans` and `orderIntents`

fixes #389 