### PR TITLE
feat(products): display products in grid by default

### DIFF
--- a/ordering/components/ProductsForOrder.js
+++ b/ordering/components/ProductsForOrder.js
@@ -96,5 +96,5 @@ function ProductsForOrder (props) {
 
 export default compose(
   connectFela(styles),
-  withState('isListView', 'setListView', true),
+  withState('isListView', 'setListView', false),
 )(ProductsForOrder)


### PR DESCRIPTION
closes #425 