### PR TITLE
Tests/cobuying algorithms

### DIFF
--- a/ordering/data/mock.js
+++ b/ordering/data/mock.js
@@ -1,0 +1,43 @@
+export const mockOrderIntents = {
+  "1": {
+    "id": 1,
+    "agentId": 4,
+    "desiredQuantity": 5,
+    "productId": 1,
+    "priceSpecId": 1,
+    "orderId": 1
+  },
+  "2": {
+    "id": 2,
+    "agentId": 4,
+    "desiredQuantity": 7,
+    "productId": 1,
+    "priceSpecId": 2,
+    "orderId": 1
+  },
+  "3": {
+    "id": 3,
+    "agentId": 1,
+    "desiredQuantity": 3,
+    "productId": 1,
+    "priceSpecId": 1,
+    "orderId": 1
+  }
+}
+
+export const mockPriceSpecs = {
+  "1": {
+    "id": 1,
+    "productId": 1,
+    "minimum": "1",
+    "price": "10",
+    "currency": "nzd"
+  },
+  "2": {
+    "id": 2,
+    "productId": 1,
+    "minimum": "10",
+    "price": "5",
+    "currency": "nzd"
+  }
+}

--- a/ordering/getters/getCurrentOrderApplicableOrderIntentByOrderAgentProduct.test.js
+++ b/ordering/getters/getCurrentOrderApplicableOrderIntentByOrderAgentProduct.test.js
@@ -1,0 +1,34 @@
+import test from 'ava'
+import getCurrentOrderApplicableOrderIntentByOrderAgentProduct from './getCurrentOrderApplicableOrderIntentByOrderAgentProduct'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getCurrentOrderApplicableOrderIntentByOrderAgentProduct: get correct applicable orderIntents', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           agentId: 1,
+           desiredQuantity: 3,
+           id: 3,
+           orderId: 1,
+           priceSpecId: 2,
+           productId: 1,
+         },
+       },
+       4: {
+         1: {
+           agentId: 4,
+           desiredQuantity: 7,
+           id: 2,
+           orderId: 1,
+           priceSpecId: 2,
+           productId: 1,
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getCurrentOrderApplicableOrderIntentByOrderAgentProduct(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderApplicableOrderIntentsFlattened.test.js
+++ b/ordering/getters/getCurrentOrderApplicableOrderIntentsFlattened.test.js
@@ -1,0 +1,28 @@
+import test from 'ava'
+import getCurrentOrderApplicableOrderIntentsFlattened from './getCurrentOrderApplicableOrderIntentsFlattened'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getCurrentOrderApplicableOrderIntentsFlattened: generate array of correct applicable orderIntents', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = [
+     {
+       agentId: 1,
+       desiredQuantity: 3,
+       id: 3,
+       orderId: 1,
+       priceSpecId: 2,
+       productId: 1,
+     },
+     {
+       agentId: 4,
+       desiredQuantity: 7,
+       id: 2,
+       orderId: 1,
+       priceSpecId: 2,
+       productId: 1,
+     }
+   ]
+
+  t.deepEqual(getCurrentOrderApplicableOrderIntentsFlattened(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderApplicablePriceSpecByProduct.test.js
+++ b/ordering/getters/getCurrentOrderApplicablePriceSpecByProduct.test.js
@@ -18,5 +18,50 @@ test('getCurrentOrderApplicablePriceSpecByProduct: generate correct applicable p
   t.deepEqual(getCurrentOrderApplicablePriceSpecByProduct(state, props), expected)
 })
 
-test.todo('test for returning the smallest min priceSpec if no orderIntents cast yet')
-test.todo('test for returning the smallest min priceSpec if no min reached yet')
+test('getCurrentOrderApplicablePriceSpecByProduct: return the smallest min priceSpec if no orderIntents cast yet', t => {
+  const state = { orderIntents: {}, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       currency: "nzd",
+       id: 1,
+       minimum: "1",
+       price: "10",
+       productId: 1,
+     },
+   }
+
+  t.deepEqual(getCurrentOrderApplicablePriceSpecByProduct(state, props), expected)
+})
+
+test('getCurrentOrderApplicablePriceSpecByProduct: return the smallest min priceSpec if no min reached yet', t => {
+  const mockPriceSpecsHighMinimums = {
+    "1": {
+      "id": 1,
+      "productId": 1,
+      "minimum": "100",
+      "price": "10",
+      "currency": "nzd"
+    },
+    "2": {
+      "id": 2,
+      "productId": 1,
+      "minimum": "1000",
+      "price": "5",
+      "currency": "nzd"
+    }
+  }
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecsHighMinimums }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       currency: "nzd",
+       id: 1,
+       minimum: "100",
+       price: "10",
+       productId: 1,
+     },
+   }
+
+  t.deepEqual(getCurrentOrderApplicablePriceSpecByProduct(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderApplicablePriceSpecByProduct.test.js
+++ b/ordering/getters/getCurrentOrderApplicablePriceSpecByProduct.test.js
@@ -1,0 +1,22 @@
+import test from 'ava'
+import getCurrentOrderApplicablePriceSpecByProduct from './getCurrentOrderApplicablePriceSpecByProduct'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getCurrentOrderApplicablePriceSpecByProduct: generate correct applicable priceSpecs', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       currency: "nzd",
+       id: 2,
+       minimum: "10",
+       price: "5",
+       productId: 1,
+     }
+   }
+
+  t.deepEqual(getCurrentOrderApplicablePriceSpecByProduct(state, props), expected)
+})
+
+test.todo('test for returning the smallest min priceSpec if no orderIntents cast yet')
+test.todo('test for returning the smallest min priceSpec if no min reached yet')

--- a/ordering/getters/getCurrentOrderCollectiveQuantityByProduct.test.js
+++ b/ordering/getters/getCurrentOrderCollectiveQuantityByProduct.test.js
@@ -1,0 +1,13 @@
+import test from 'ava'
+import getCurrentOrderCollectiveQuantityByProduct from './getCurrentOrderCollectiveQuantityByProduct'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getCurrentOrderCollectiveQuantityByProduct: generate correct collective quantity per product for current order', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: 10
+   }
+
+  t.deepEqual(getCurrentOrderCollectiveQuantityByProduct(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderCollectiveQuantityByProductPrice.test.js
+++ b/ordering/getters/getCurrentOrderCollectiveQuantityByProductPrice.test.js
@@ -14,3 +14,11 @@ test('getCurrentOrderCollectiveQuantityByProductPrice: generate correct collecti
 
   t.deepEqual(getCurrentOrderCollectiveQuantityByProductPrice(state, props), expected)
 })
+
+test('getCurrentOrderCollectiveQuantityByProductPrice: return empty obj if no intents', t => {
+  const state = { orderIntents: {}, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {}
+
+  t.deepEqual(getCurrentOrderCollectiveQuantityByProductPrice(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderCollectiveQuantityByProductPrice.test.js
+++ b/ordering/getters/getCurrentOrderCollectiveQuantityByProductPrice.test.js
@@ -1,0 +1,16 @@
+import test from 'ava'
+import getCurrentOrderCollectiveQuantityByProductPrice from './getCurrentOrderCollectiveQuantityByProductPrice'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getCurrentOrderCollectiveQuantityByProductPrice: generate correct collective quantities for current order', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       1: 8,
+       2: 10
+     }
+   }
+
+  t.deepEqual(getCurrentOrderCollectiveQuantityByProductPrice(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderId.test.js
+++ b/ordering/getters/getCurrentOrderId.test.js
@@ -1,0 +1,16 @@
+import test from 'ava'
+import getCurrentOrderId from './getCurrentOrderId'
+
+test('getCurrentOrderId: can get orderId from taskPlan props', t => {
+  const state = {}
+  const props = { taskPlan: { params: { orderId: 23 } } }
+
+  t.deepEqual(getCurrentOrderId(state, props), 23)
+})
+
+test('getCurrentOrderId: can get orderId from match props', t => {
+  const state = {}
+  const props = { match: { params: { orderId: 23 } } }
+
+  t.deepEqual(getCurrentOrderId(state, props), 23)
+})

--- a/ordering/getters/getCurrentOrderIntentsByProductAgentPrice.test.js
+++ b/ordering/getters/getCurrentOrderIntentsByProductAgentPrice.test.js
@@ -40,3 +40,11 @@ test('getCurrentOrderIntentsByProductAgentPrice: orderIntents exist on state', t
 
   t.deepEqual(getCurrentOrderIntentsByProductAgentPrice(state, props), expected)
 })
+
+test('getCurrentOrderIntentsByProductAgentPrice: return empty obj if no intents', t => {
+  const state = { orderIntents: {} }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {}
+
+  t.deepEqual(getCurrentOrderIntentsByProductAgentPrice(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderIntentsByProductAgentPrice.test.js
+++ b/ordering/getters/getCurrentOrderIntentsByProductAgentPrice.test.js
@@ -1,0 +1,42 @@
+import test from 'ava'
+import getCurrentOrderIntentsByProductAgentPrice from './getCurrentOrderIntentsByProductAgentPrice'
+import { mockOrderIntents } from '../data/mock'
+
+test('getCurrentOrderIntentsByProductAgentPrice: orderIntents exist on state', t => {
+  const state = { orderIntents: mockOrderIntents }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           agentId: 1,
+           desiredQuantity: 3,
+           id: 3,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+       },
+       4: {
+         1: {
+           agentId: 4,
+           desiredQuantity: 5,
+           id: 1,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+         2: {
+           agentId: 4,
+           desiredQuantity: 7,
+           id: 2,
+           orderId: 1,
+           priceSpecId: 2,
+           productId: 1,
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getCurrentOrderIntentsByProductAgentPrice(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderIntentsByProductPriceAgent.test.js
+++ b/ordering/getters/getCurrentOrderIntentsByProductPriceAgent.test.js
@@ -40,3 +40,11 @@ test('getCurrentOrderIntentsByProductPriceAgent: orderIntents exist on state', t
 
   t.deepEqual(getCurrentOrderIntentsByProductPriceAgent(state, props), expected)
 })
+
+test('getCurrentOrderIntentsByProductPriceAgent: return empty obj if no intents', t => {
+  const state = { orderIntents: {} }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {}
+
+  t.deepEqual(getCurrentOrderIntentsByProductPriceAgent(state, props), expected)
+})

--- a/ordering/getters/getCurrentOrderIntentsByProductPriceAgent.test.js
+++ b/ordering/getters/getCurrentOrderIntentsByProductPriceAgent.test.js
@@ -1,0 +1,42 @@
+import test from 'ava'
+import getCurrentOrderIntentsByProductPriceAgent from './getCurrentOrderIntentsByProductPriceAgent'
+import { mockOrderIntents } from '../data/mock'
+
+test('getCurrentOrderIntentsByProductPriceAgent: orderIntents exist on state', t => {
+  const state = { orderIntents: mockOrderIntents }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           agentId: 1,
+           desiredQuantity: 3,
+           id: 3,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+         4: {
+           agentId: 4,
+           desiredQuantity: 5,
+           id: 1,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+       },
+       2: {
+         4: {
+           agentId: 4,
+           desiredQuantity: 7,
+           id: 2,
+           orderId: 1,
+           priceSpecId: 2,
+           productId: 1,
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getCurrentOrderIntentsByProductPriceAgent(state, props), expected)
+})

--- a/ordering/getters/getDerivedOrderIntents.js
+++ b/ordering/getters/getDerivedOrderIntents.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect'
-import { map, addIndex, indexBy, prop, mapObjIndexed, slice, find, isNil, merge, isEmpty } from 'ramda'
+import { map, addIndex, indexBy, prop, mapObjIndexed, slice, find, isNil, merge, isEmpty, filter, complement } from 'ramda'
 
 import getSortedByMinPriceSpecsByProduct from '../../supply/getters/getSortedByMinPriceSpecsByProduct'
 import getOrderIntentsByOrderAgentProductPrice from './getOrderIntentsByOrderAgentProductPrice'
@@ -13,6 +13,7 @@ export default createSelector(
   (orderIntents, priceSpecs) => {
     return map(map(mapObjIndexed((intents, productId) => {
       // intents are by priceSpecId
+      // TODO: IK: i'm not sure why this guard logic is here, should always be priceSpecs for any productId? needs testing before removal though
       const allPriceSpecsForProduct = priceSpecs[productId] || {}
       if (isEmpty(allPriceSpecsForProduct)) return {}
       // now, for each priceSpec in allPriceSpecsForProduct, we want an intent
@@ -27,14 +28,14 @@ export default createSelector(
         const nextPriceSpecs = slice(i, arr.length, arr)
         const nextBestPriceSpec = find((ps) => intents[ps.id], nextPriceSpecs)
 
-        // this is a bit sub-optimal, leads to { undefined: {} } in indexedIntents at end of this getter
-        // could fix by removing all non-number keys after?
         if (isNil(nextBestPriceSpec)) return {}
         // consider omitting the intent id, as it doesn't make sense when same intent id is across multiple priceSpecs
         return merge(intents[nextBestPriceSpec.id], { priceSpecId: id })
       }, allPriceSpecsForProduct)
+      // remove all empty objects (generated if isNil(nextBestPriceSpec) above)
+      const onlyValidIntentsAtEachPriceSpec = filter(complement(isEmpty), intentsAtEachPriceSpec)
 
-      return indexByPriceSpecId(intentsAtEachPriceSpec)
+      return indexByPriceSpecId(onlyValidIntentsAtEachPriceSpec)
     })), orderIntents)
   }
 )

--- a/ordering/getters/getDerivedOrderIntents.test.js
+++ b/ordering/getters/getDerivedOrderIntents.test.js
@@ -1,0 +1,53 @@
+import test from 'ava'
+import getDerivedOrderIntents from './getDerivedOrderIntents'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getDerivedOrderIntents: generate correct derived orderIntents', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           1: {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           2: {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+       4: {
+         1: {
+           1: {
+             agentId: 4,
+             desiredQuantity: 5,
+             id: 1,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           2: {
+             agentId: 4,
+             desiredQuantity: 7,
+             id: 2,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getDerivedOrderIntents(state), expected)
+})

--- a/ordering/getters/getDerivedOrderIntents.test.js
+++ b/ordering/getters/getDerivedOrderIntents.test.js
@@ -51,3 +51,74 @@ test('getDerivedOrderIntents: generate correct derived orderIntents', t => {
 
   t.deepEqual(getDerivedOrderIntents(state), expected)
 })
+
+test.todo('test for case where isEmpty(allPriceSpecsForProduct) if this in fact is necessary guard logic?')
+
+test('getDerivedOrderIntents: if agent has no intent at low minimum / high price priceSpec, do not derive intent for that priceSpec', t => {
+  const mockOrderIntentsNoDesiredQuantityAtLowMinPriceSpec = {
+    "1": {
+      "id": 1,
+      "agentId": 4,
+      "desiredQuantity": 5,
+      "productId": 1,
+      "priceSpecId": 1,
+      "orderId": 1
+    },
+    "2": {
+      "id": 2,
+      "agentId": 4,
+      "desiredQuantity": 7,
+      "productId": 1,
+      "priceSpecId": 2,
+      "orderId": 1
+    },
+    "3": {
+      "id": 3,
+      "agentId": 1,
+      "desiredQuantity": 2,
+      "productId": 1,
+      "priceSpecId": 2,
+      "orderId": 1
+    }
+  }
+  const state = { orderIntents: mockOrderIntentsNoDesiredQuantityAtLowMinPriceSpec, priceSpecs: mockPriceSpecs }
+  const props = { taskPlan: { params: { orderId: 1 } } }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           2: {
+             agentId: 1,
+             desiredQuantity: 2,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+       4: {
+         1: {
+           1: {
+             agentId: 4,
+             desiredQuantity: 5,
+             id: 1,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           2: {
+             agentId: 4,
+             desiredQuantity: 7,
+             id: 2,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getDerivedOrderIntents(state, props), expected)
+})

--- a/ordering/getters/getDerivedOrderIntentsByOrderProductPrice.test.js
+++ b/ordering/getters/getDerivedOrderIntentsByOrderProductPrice.test.js
@@ -1,0 +1,51 @@
+import test from 'ava'
+import getDerivedOrderIntentsByOrderProductPrice from './getDerivedOrderIntentsByOrderProductPrice'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getDerivedOrderIntentsByOrderProductPrice: regroup derived orderIntents', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const expected = {
+     1: {
+       1: {
+         1: [
+           {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           {
+             agentId: 4,
+             desiredQuantity: 5,
+             id: 1,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           }
+         ],
+         2: [
+           {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+           {
+             agentId: 4,
+             desiredQuantity: 7,
+             id: 2,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           }
+         ]
+       }
+     }
+   }
+
+  t.deepEqual(getDerivedOrderIntentsByOrderProductPrice(state), expected)
+})

--- a/ordering/getters/getDerivedOrderIntentsUngrouped.test.js
+++ b/ordering/getters/getDerivedOrderIntentsUngrouped.test.js
@@ -1,0 +1,43 @@
+import test from 'ava'
+import getDerivedOrderIntentsUngrouped from './getDerivedOrderIntentsUngrouped'
+import { mockOrderIntents, mockPriceSpecs } from '../data/mock'
+
+test('getDerivedOrderIntentsUngrouped: flatten derived orderIntents', t => {
+  const state = { orderIntents: mockOrderIntents, priceSpecs: mockPriceSpecs }
+  const expected = [
+   {
+     agentId: 1,
+     desiredQuantity: 3,
+     id: 3,
+     orderId: 1,
+     priceSpecId: 1,
+     productId: 1,
+   },
+   {
+     agentId: 1,
+     desiredQuantity: 3,
+     id: 3,
+     orderId: 1,
+     priceSpecId: 2,
+     productId: 1,
+   },
+   {
+     agentId: 4,
+     desiredQuantity: 5,
+     id: 1,
+     orderId: 1,
+     priceSpecId: 1,
+     productId: 1,
+   },
+   {
+     agentId: 4,
+     desiredQuantity: 7,
+     id: 2,
+     orderId: 1,
+     priceSpecId: 2,
+     productId: 1,
+   }
+  ]
+
+  t.deepEqual(getDerivedOrderIntentsUngrouped(state), expected)
+})

--- a/ordering/getters/getOrderIntents.test.js
+++ b/ordering/getters/getOrderIntents.test.js
@@ -1,0 +1,8 @@
+import test from 'ava'
+import getOrderIntents from './getOrderIntents'
+
+test('getOrderIntents: orderIntents exist on state', t => {
+  const state = { orderIntents: {} }
+
+  t.deepEqual(getOrderIntents(state), {})
+})

--- a/ordering/getters/getOrderIntentsByOrderAgentProductPrice.test.js
+++ b/ordering/getters/getOrderIntentsByOrderAgentProductPrice.test.js
@@ -1,0 +1,45 @@
+import test from 'ava'
+import getOrderIntentsByOrderAgentProductPrice from './getOrderIntentsByOrderAgentProductPrice'
+import { mockOrderIntents } from '../data/mock'
+
+test('getOrderIntentsByOrderAgentProductPrice: orderIntents exist on state', t => {
+  const state = { orderIntents: mockOrderIntents }
+  const expected = {
+   1: {
+     1: {
+       1: {
+         1: {
+           agentId: 1,
+           desiredQuantity: 3,
+           id: 3,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+       },
+     },
+     4: {
+       1: {
+         1: {
+           agentId: 4,
+           desiredQuantity: 5,
+           id: 1,
+           orderId: 1,
+           priceSpecId: 1,
+           productId: 1,
+         },
+         2: {
+           agentId: 4,
+           desiredQuantity: 7,
+           id: 2,
+           orderId: 1,
+           priceSpecId: 2,
+           productId: 1,
+         },
+       },
+     },
+   },
+  }
+
+  t.deepEqual(getOrderIntentsByOrderAgentProductPrice(state), expected)
+})

--- a/ordering/getters/getOrderIntentsByOrderProductAgentPrice.test.js
+++ b/ordering/getters/getOrderIntentsByOrderProductAgentPrice.test.js
@@ -1,0 +1,43 @@
+import test from 'ava'
+import getOrderIntentsByOrderProductAgentPrice from './getOrderIntentsByOrderProductAgentPrice'
+import { mockOrderIntents } from '../data/mock'
+
+test('getOrderIntentsByOrderProductAgentPrice: orderIntents exist on state', t => {
+  const state = { orderIntents: mockOrderIntents }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           1: {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+         },
+         4: {
+           1: {
+             agentId: 4,
+             desiredQuantity: 5,
+             id: 1,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           2: {
+             agentId: 4,
+             desiredQuantity: 7,
+             id: 2,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getOrderIntentsByOrderProductAgentPrice(state), expected)
+})

--- a/ordering/getters/getOrderIntentsByOrderProductPriceAgent.test.js
+++ b/ordering/getters/getOrderIntentsByOrderProductPriceAgent.test.js
@@ -1,0 +1,43 @@
+import test from 'ava'
+import getOrderIntentsByOrderProductPriceAgent from './getOrderIntentsByOrderProductPriceAgent'
+import { mockOrderIntents } from '../data/mock'
+
+test('getOrderIntentsByOrderProductPriceAgent: orderIntents exist on state', t => {
+  const state = { orderIntents: mockOrderIntents }
+  const expected = {
+     1: {
+       1: {
+         1: {
+           1: {
+             agentId: 1,
+             desiredQuantity: 3,
+             id: 3,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+           4: {
+             agentId: 4,
+             desiredQuantity: 5,
+             id: 1,
+             orderId: 1,
+             priceSpecId: 1,
+             productId: 1,
+           },
+         },
+         2: {
+           4: {
+             agentId: 4,
+             desiredQuantity: 7,
+             id: 2,
+             orderId: 1,
+             priceSpecId: 2,
+             productId: 1,
+           },
+         },
+       },
+     },
+   }
+
+  t.deepEqual(getOrderIntentsByOrderProductPriceAgent(state), expected)
+})

--- a/supply/getters/getPriceSpecs.test.js
+++ b/supply/getters/getPriceSpecs.test.js
@@ -1,0 +1,8 @@
+import test from 'ava'
+import getPriceSpecs from './getPriceSpecs'
+
+test('getPriceSpecs: priceSpecs exist on state', t => {
+  const state = { priceSpecs: {} }
+
+  t.deepEqual(getPriceSpecs(state), {})
+})

--- a/supply/getters/getPriceSpecsByProduct.test.js
+++ b/supply/getters/getPriceSpecsByProduct.test.js
@@ -1,0 +1,27 @@
+import test from 'ava'
+import getPriceSpecsByProduct from './getPriceSpecsByProduct'
+import { mockPriceSpecs } from '../../ordering/data/mock'
+
+test('getPriceSpecsByProduct: group priceSpecs correctly by product', t => {
+  const state = { priceSpecs: mockPriceSpecs }
+  const expected = {
+     1: [
+       {
+         currency: "nzd",
+         id: 1,
+         minimum: "1",
+         price: "10",
+         productId: 1,
+       },
+       {
+         currency: "nzd",
+         id: 2,
+         minimum: "10",
+         price: "5",
+         productId: 1,
+       },
+     ],
+   }
+
+  t.deepEqual(getPriceSpecsByProduct(state), expected)
+})

--- a/supply/getters/getSortedByMinPriceSpecsByProduct.test.js
+++ b/supply/getters/getSortedByMinPriceSpecsByProduct.test.js
@@ -1,0 +1,27 @@
+import test from 'ava'
+import getSortedByMinPriceSpecsByProduct from './getSortedByMinPriceSpecsByProduct'
+import { mockPriceSpecs } from '../../ordering/data/mock'
+
+test('getSortedByMinPriceSpecsByProduct: sort grouped priceSpecs by minimum correctly', t => {
+  const state = { priceSpecs: mockPriceSpecs }
+  const expected = {
+     1: [
+      {
+         currency: "nzd",
+         id: 2,
+         minimum: "10",
+         price: "5",
+         productId: 1,
+       },
+      {
+         currency: "nzd",
+         id: 1,
+         minimum: "1",
+         price: "10",
+         productId: 1,
+       },
+     ],
+   }
+
+  t.deepEqual(getSortedByMinPriceSpecsByProduct(state), expected)
+})

--- a/tasks/util/createTaskPlan.test.js
+++ b/tasks/util/createTaskPlan.test.js
@@ -5,8 +5,8 @@ import * as taskRecipes from '../data/recipes'
 
 /*
 TODO fix tests
-
-test('create simple task', (t) => {
+*/
+test.skip('create simple task', (t) => {
   const assignee = Symbol('assignee')
   const taskRecipe = taskRecipes.setupGroup
   const expected = [
@@ -18,7 +18,7 @@ test('create simple task', (t) => {
   t.deepEqual(taskPlans, expected)
 })
 
-test('create nested task', (t) => {
+test.skip('create nested task', (t) => {
   const assignee = Symbol('assignee')
   const taskRecipe = taskRecipes.finishPrereqs
   const expected = [
@@ -30,4 +30,3 @@ test('create nested task', (t) => {
   const taskPlans = createTaskPlan(options)
   t.deepEqual(taskPlans, expected)
 })
-*/


### PR DESCRIPTION
coverage of the getters used in the two applications of the buying algorithm (intents -> plans, and displaying current state of group intents on the client)

interested in thoughts on:
- are equality tests the ideal way to go about this? could try and write tests that aren't specific to the mock data used, seems tricky / fraught though...
- should the mock data be more complex for more thorough testing?

this is s start for now at least, makes it easier to protect / refactor these getters if need be

closes #452 